### PR TITLE
Ajout de la possibilité de configurer le presta chèques.

### DIFF
--- a/lang/bank_en.php
+++ b/lang/bank_en.php
@@ -27,6 +27,8 @@ $GLOBALS[$GLOBALS['idx_lang']] = array(
 'label_notifications' => 'Notifications',
 'label_email_ticket_admin' => 'Administrator\'s email address for reception of transaction tickets',
 
+'label_configuration_ordre' => 'Pay to the order of',
+'label_configuration_adresse' => 'Adress where checks should be sent',
 
 'carte_bleu'=>'Credit Card',
 'choisissez_cb'=>'Select your Credit Card:',

--- a/lang/bank_fr.php
+++ b/lang/bank_fr.php
@@ -27,6 +27,8 @@ $GLOBALS[$GLOBALS['idx_lang']] = array(
 'label_notifications' => 'Notifications',
 'label_email_ticket_admin' => 'Email pour l\'envoi des tickets d\'achat admin',
 
+'label_configuration_ordre' => 'Ordre',
+'label_configuration_adresse' => 'Adresse où envoyer les chèques',
 
 'carte_bleu'=>'Carte Bleue',
 'choisissez_cb'=>'Choisissez votre carte bancaire&nbsp;:',

--- a/presta/cheque/inc-configurer.html
+++ b/presta/cheque/inc-configurer.html
@@ -1,0 +1,15 @@
+<ul>
+	#SET{name,#ENV{casier,''}_ordre}#SET{obli,''}#SET{defaut,''}#SET{erreurs,#ENV**{erreurs}|table_valeur{#GET{name}}}
+	<li class="editer editer_[(#GET{name})][ (#GET{obli})][ (#GET{erreurs}|oui)erreur]">
+		<label for="#GET{name}"><:bank:label_configuration_ordre:></label>[
+		<span class="erreur_message">(#GET{erreurs})</span>
+		]<input type="text" name="#ENV{casier,''}[ordre]" class="text" value="[(#ENV*{#ENV{casier,''}}|table_valeur{ordre,#GET{defaut}})]" id="#GET{name}" [(#HTML5|et{#GET{obli}})required='required']/>
+	</li>
+	#SET{name,#ENV{casier,''}_adresse}#SET{obli,''}#SET{defaut,''}#SET{erreurs,#ENV**{erreurs}|table_valeur{#GET{name}}}
+	<li class="editer editer_[(#GET{name})][ (#GET{obli})][ (#GET{erreurs}|oui)erreur]">
+		<label for="#GET{name}"><:bank:label_configuration_adresse:></label>[
+		<span class="erreur_message">(#GET{erreurs})</span>
+		]<textarea name="#ENV{casier,''}[adresse]" class="textarea">
+[(#ENV*{#ENV{casier,''}}|table_valeur{adresse,#GET{defaut}})]</textarea>
+	</li>
+</ul>

--- a/presta/cheque/payer/acte.html
+++ b/presta/cheque/payer/acte.html
@@ -16,11 +16,13 @@
 	[(#AUTORISER{encaissercheque,transaction,#ID_TRANSACTION}|non|ou{#SESSION{id_auteur}|=={#ID_AUTEUR}})
 	<p>Imprimez cette page et envoyez là avec votre chèque à l&#8217;adresse&nbsp;:</p>
 	<p>
+          [(#CONFIG{bank_paiement/config_cheque/adresse}|propre|sinon{
 		Nursit<br />
 		2 allée du clos des Hydrangeas<br />
 		59700 Marcq-En-Baroeul
+          })]
 	</p>
-	<p>Chèque établi à l'ordre de &laquo;&nbsp;<i>Nursit</i>&nbsp;&raquo;</p>
+	<p>Chèque établi à l'ordre de &laquo;&nbsp;<i>[(#CONFIG{bank_paiement/config_cheque/ordre}|sinon{Nursit})]</i>&nbsp;&raquo;</p>
 	<p>La facture sera disponible dans votre espace client dès votre règlement pris en compte.</p>
 	<p class="small"><strong>Attention</strong> : cette commande ne sera validée par nos services qu&#8217;à <b>encaissement</b> de votre chèque.
 		Il vous appartient de prévoir un délai d&#8217;acheminement et d&#8217;encaissement suffisant avant expiration de vos services


### PR DESCRIPTION
Il est possible de définir l'ordre des chèques ainsi que l'adresse à
laquelle ils doivent être envoyés. Si ces informations ne sont pas
données, les informations de Nursit sont utilisées.
