### PR TITLE
Utilisation de l'API autoriser pour vérifier les droits d'encaissement des chèques

### DIFF
--- a/bank_options.php
+++ b/bank_options.php
@@ -58,4 +58,20 @@ function autoriser_utilisermodepaiement_dist($faire, $mode='', $id=0, $qui = NUL
 	}
 	return true;
 }
+
+/* Par défaut, on interdit la personne qui a payé d'encaisser son
+ * propre chèque, même si la personne en question dispose des droits
+ * webmaster. */
+function autoriser_transaction_encaissercheque_dist($faire, $type, $id_transaction, $qui, $opt) { 
+	if(autoriser('webmestre')) {
+		include_spip('base/abstract_sql');
+
+		$id_auteur = sql_getfetsel("id_auteur", "spip_transactions", "id_transaction=" . intval($id_transaction));
+		if($id_auteur != $qui['id_auteur']) {
+			return true;
+		}
+	}
+
+	return false;
+}
 ?>

--- a/presta/cheque/payer/acte.html
+++ b/presta/cheque/payer/acte.html
@@ -13,7 +13,7 @@
 <BOUCLE_trans(TRANSACTIONS){id_transaction}{transaction_hash}>
 <div class="payer_mode payer_cheque payer_acte">
 	<p class="titre"><:bank:payer_par_cheque:></p>
-	[(#AUTORISER{encaissercheque,transaction,#ID_TRANSACTION}|non|ou{#SESSION{id_auteur}|=={#ID_AUTEUR}})
+	[(#AUTORISER{encaissercheque,transaction,#ID_TRANSACTION}|non)
 	<p><:bank:info_cheque_imprimer{montant=#MONTANT,transaction=#ID_TRANSACTION}:></p>
 	<p>[(#CONFIG{bank_paiement/config_cheque/adresse}|propre|sinon{
 		#NOM_SITE_SPIP<br />
@@ -25,7 +25,7 @@
 	<p><:bank:info_cheque_facture:></p>
 	[<p class="small">(#CONFIG{bank_paiement/config_cheque/notice,''}|propre)</p>]
 	]
-	[(#AUTORISER{encaissercheque,transaction,#ID_TRANSACTION}|non|ou{#SESSION{id_auteur}|=={#ID_AUTEUR}}|non)
+	[(#AUTORISER{encaissercheque,transaction,#ID_TRANSACTION})
 	<div class='boutons'>
 	[(#BOUTON_ACTION{<:bank:bouton_enregistrer_reglement_cheque:>,#ENV{action}|parametre_url{id_transaction,#ID_TRANSACTION}|parametre_url{hash,#TRANSACTION_HASH}})]
 	</div>


### PR DESCRIPTION
Ajout d'une nouvelle fonction `autoriser_transaction_encaissercheque_dist()` qui se charge de vérifier que l'utilisateur dispose bien des droits « webmestre » et qu'il ne tente pas d'encaisser son propre chèque.
