### PR TITLE
Corriger l'erreur squelette "filtre ,#SELF..."

### DIFF
--- a/presta/paypalexpress/payer/acte.html
+++ b/presta/paypalexpress/payer/acte.html
@@ -13,7 +13,10 @@
 <div class='payer_mode payer_paypalexpress payer_acte'>
 	<p class="titre h4"><:bank:payer_avec{nom=Paypal Express}:></p>
 	<div class='boutons' title="<:bank:payer_avec{nom=Paypal}|attribut_html:>">
-		[(#BOUTON_ACTION{#ENV{logo}|balise_img{<:bank:payer_avec{nom=Paypal}:>},[(#URL_ACTION_AUTEUR{paypalexpress_order,[(#ID_TRANSACTION)-#ENV{config/presta}[-(#ENV{config}|bank_config_id)]]}|parametre_url{url_confirm,#ENV{url_confirm}},#SELF)]})]
+		[(#BOUTON_ACTION{
+		#ENV{logo}|balise_img{<:bank:payer_avec{nom=Paypal}:>},
+		[(#URL_ACTION_AUTEUR{paypalexpress_order,[(#ID_TRANSACTION)-#ENV{config/presta}[-(#ENV{config}|bank_config_id)]]}|parametre_url{url_confirm,#ENV{url_confirm}})],
+		#SELF})]
 	</div>
 	[(#ENV{sandbox}|oui)<div class="info"><:bank:info_mode_test{presta=PaypalExpress}:></div>]
 </div>


### PR DESCRIPTION
Les paramètres du bouton action donnent une erreur squelette `filtre ,#SELF non défini`. 
Difficile a détectée car le formulaire fonctionne malgré l'erreur.

Au passage on améliore la lisibilité des paramètres du bouton action.