### PR TITLE
Ne pas planter le JS si le nom du site contient <br />

### DIFF
--- a/presta/stripe/call/request.php
+++ b/presta/stripe/call/request.php
@@ -109,7 +109,7 @@ function presta_stripe_call_request_dist($id_transaction, $transaction_hash, $co
 	$contexte['amount'] = $montant;
 	$contexte['currency'] = 'eur';
 	$contexte['key'] = ($config['mode_test']?$config['PUBLISHABLE_KEY_test']:$config['PUBLISHABLE_KEY']);
-	$contexte['name'] = textebrut($GLOBALS['meta']['nom_site']);
+	$contexte['name'] = textebrut(supprimer_tags($GLOBALS['meta']['nom_site']));
 	$contexte['description'] = _T('bank:titre_transaction') . '#'.$id_transaction;
 	$contexte['image'] = find_in_path('img/logo-paiement-stripe.png');
 


### PR DESCRIPTION
Bonjour,

J'ai un site sur lequel le nom du site contient un saut de ligne, et ça générait un js avec le name sur 2 lignes qui plantait le JS (le paiement passait directement en annulé).

