### PR TITLE
l'API de Stripe ne supportant pas les paramètres avec comme valeur un…

### DIFF
--- a/inc/bank.php
+++ b/inc/bank.php
@@ -464,7 +464,7 @@ function bank_description_transaction($id_transaction, $transaction=null) {
 
 	if (!$description['libelle'] and $description['description']) {
 		$description['libelle'] = $description['description'];
-		$description['description'] = '';
+		unset($description['description']);
 	}
 
 	return $description;


### PR DESCRIPTION
l'API de Stripe ne supportant pas les paramètres ayant comme valeur une chaîne vide il faut supprimer le paramètre plutôt que le vider (sinon on se chope l'erreur You passed an empty string for 'line_items[0][description]' à la compilation)