### PR TITLE
La devise par défaut peut être modifiée

### DIFF
--- a/bank_options.php
+++ b/bank_options.php
@@ -188,7 +188,11 @@ function bank_annonce_version_plugin($format = 'string'){
  *     Identifiant ISO 4217 alpha d'une devise
  */
 function bank_devise_defaut() {
-	$devise = 'EUR';
+	$devise = array(
+		'code' => 'EUR',
+		'code_num' => 978,
+		'fraction' => 2,
+	);
 	
 	$devise = pipeline('bank_devise_defaut', $devise);
 	

--- a/bank_options.php
+++ b/bank_options.php
@@ -36,7 +36,8 @@ if (isset($GLOBALS['meta']['bank_paiement'])
 if (!function_exists('affiche_monnaie')){
 	function affiche_monnaie($valeur, $decimales = 2, $unite = true){
 		if ($unite===true){
-			$unite = "&nbsp;EUR";
+			$devise_defaut = bank_devise_defaut();
+			$unite = '&nbsp;'.$devise_defaut['code'];
 			if (substr(trim($valeur), -1)=="%"){
 				$unite = "&nbsp;%";
 			}

--- a/bank_options.php
+++ b/bank_options.php
@@ -215,7 +215,7 @@ function bank_devise_defaut() {
  * 		Renvoie true si la devise est ok, false sinon
  * 
  */
-function bank_tester_devise_presta($presta, $devise=null) {
+function bank_tester_devise_presta($presta, $devise = null) {
 	$ok = false;
 	
 	// Si pas de devise, on prend celle générale par défaut
@@ -223,23 +223,25 @@ function bank_tester_devise_presta($presta, $devise=null) {
 		$devise_defaut = bank_devise_defaut();
 		$devise = $devise_defaut['code'];
 	}
-	
+
 	// Par défaut on accepte l'euro comme avant, ce qui évite d'implémenter partout
 	$devises_ok = array('EUR');
-	
-	// Si le presta a une fonction qui définit les devises supportées, on l'utilise
+
+	// Si le presta a une fonction qui définit les devises supportées, on l'utilise.
+	// Elle retourne soit un tableau, soit un booléen pour les accepter toutes.
 	if ($lister_devises = charger_fonction('lister_devises', 'presta/' . $presta, true)) {
 		$devises_ok = $lister_devises();
 	}
-	
-	// On normalise
-	$devise = strtoupper($devise);
-	$devises_ok = array_map('strtoupper', $devises_ok);
-	
+
 	// Et enfin on teste
-	if (in_array($devise, $devises_ok)) {
-		$ok = true;
+	if (is_array($devises_ok)) {
+		// On normalise
+		$devise = strtoupper($devise);
+		$devises_ok = array_map('strtoupper', $devises_ok);
+		$ok = in_array($devise, $devises_ok);
+	} elseif (is_bool($devises_ok)) {
+		$ok = $devises_ok;
 	}
-	
+
 	return $ok;
 }

--- a/bank_options.php
+++ b/bank_options.php
@@ -179,3 +179,18 @@ function bank_annonce_version_plugin($format = 'string'){
 
 	return $infos;
 }
+
+/**
+ * Renvoie la devise par défaut utilisée par Bank, modifiable par pipeline
+ * 
+ * @pipeline_appel bank_devise_defaut
+ * @return string
+ *     Identifiant ISO 4217 alpha d'une devise
+ */
+function bank_devise_defaut() {
+	$devise = 'EUR';
+	
+	$devise = pipeline('bank_devise_defaut', $devise);
+	
+	return $devise;
+}

--- a/bank_options.php
+++ b/bank_options.php
@@ -80,16 +80,17 @@ function bank_affiche_payer($config, $type, $id_transaction, $transaction_hash, 
 	
 	$devise_defaut = bank_devise_defaut();
 	
-	if (
-		bank_tester_devise_presta($config['presta'], $devise_defaut['code'])
-		and $payer = charger_fonction($quoi, 'presta/' . $config['presta'] . '/payer', true)
-	) {
-		return $payer($config, $id_transaction, $transaction_hash, $options);
+	if (!bank_tester_devise_presta($config['presta'], $devise_defaut['code'])) {
+		spip_log('La devise ' . $devise_defaut['code'] . 'n’est pas supportée pour presta=' . $config['presta'], 'bank' . _LOG_ERREUR);
+		return '';
+	}
+	
+	if (!$payer = charger_fonction($quoi, 'presta/' . $config['presta'] . '/payer', true)) {
+		spip_log("Pas de payer/$quoi pour presta=" . $config['presta'], "bank" . _LOG_ERREUR);
+		return '';
 	}
 
-	spip_log("Pas de payer/$quoi pour presta=" . $config['presta'], "bank" . _LOG_ERREUR);
-	
-	return "";
+	return $payer($config, $id_transaction, $transaction_hash, $options);
 }
 
 /**

--- a/bank_options.php
+++ b/bank_options.php
@@ -228,7 +228,7 @@ function bank_tester_devise_presta($presta, $devise=null) {
 	$devises_ok = array('EUR');
 	
 	// Si le presta a une fonction qui définit les devises supportées, on l'utilise
-	if ($lister_devises = charger_fonction('lister_devises', 'presta/' . $config['presta'], true)) {
+	if ($lister_devises = charger_fonction('lister_devises', 'presta/' . $presta, true)) {
 		$devises_ok = $lister_devises();
 	}
 	

--- a/paquet.xml
+++ b/paquet.xml
@@ -1,7 +1,7 @@
 <paquet
 	prefix="bank"
 	categorie="outil"
-	version="4.3.3"
+	version="4.4.0"
 	etat="stable"
 	compatibilite="[3.1.0;3.3.*]"
 	logo="prive/themes/spip/images/bank-32.png"

--- a/paquet.xml
+++ b/paquet.xml
@@ -22,6 +22,7 @@
 	<pipeline nom="affiche_auteurs_interventions" inclure="bank_fonctions.php" />
 	<pipeline nom="taches_generales_cron" inclure="bank_fonctions.php" />
 
+	<pipeline nom="bank_devise_defaut" action="" />
 	<pipeline nom="bank_dsp2_renseigner_facturation" action="" />
 	<pipeline nom="bank_abos_activer_abonnement" action="" />
 	<pipeline nom="bank_abos_decrire_echeance" action="" />

--- a/presta/cheque/lister_devises.php
+++ b/presta/cheque/lister_devises.php
@@ -1,0 +1,9 @@
+<?php
+
+if (!defined('_ECRIRE_INC_VERSION')) {
+	return;
+}
+
+function presta_cheque_lister_devises_dist() {
+	return true;
+}

--- a/presta/cmcic/call/request.php
+++ b/presta/cmcic/call/request.php
@@ -88,7 +88,8 @@ function presta_cmcic_call_request_dist($id_transaction, $transaction_hash, $con
 
 
 	// Currency : ISO 4217 compliant
-	$devise = "EUR";
+	$devise_defaut = bank_devise_defaut();
+	$devise = strtoupper($devise_defaut['code']);
 	// Amount : format  "xxxxx.yy" (no spaces)
 	$montant = $row['montant'];
 	$contexte['version'] = $oTpe->sVersion;

--- a/presta/ogone/call/request.php
+++ b/presta/ogone/call/request.php
@@ -90,8 +90,9 @@ function presta_ogone_call_request_dist($id_transaction, $transaction_hash, $con
 	$contexte['operation'] = "SAL"; // c'est un paiement a l'acte immediat
 
 	// passage en centimes d'euros : round en raison des approximations de calcul de PHP
-	$contexte['currency'] = "EUR";
-	$contexte['amount'] = intval(round(100*$row['montant'], 0));
+	$devise_defaut = bank_devise_defaut();
+	$contexte['currency'] = $devise_defaut['code'];
+	$contexte['amount'] = intval(round((10**$devise_defaut['fraction']) * $row['montant'], 0));
 
 	#if (strlen($montant)<3)
 	#	$montant = str_pad($montant,3,'0',STR_PAD_LEFT);

--- a/presta/paybox/call/directplus.php
+++ b/presta/paybox/call/directplus.php
@@ -40,6 +40,7 @@ function presta_paybox_call_directplus_dist($id_transaction, $transaction_hash, 
 	}
 	$config['mode'] .= "_dplus"; // pour les logs
 	$mode = $config['mode'];
+	$devise_defaut = bank_devise_defaut();
 
 	if (!$row = sql_fetsel("*", "spip_transactions", "id_transaction=" . intval($id_transaction) . " AND transaction_hash=" . sql_quote($transaction_hash))){
 		spip_log("Transaction inconnue $id_transaction/$transaction_hash", $mode . _LOG_ERREUR);
@@ -62,7 +63,7 @@ function presta_paybox_call_directplus_dist($id_transaction, $transaction_hash, 
 	$mail = sql_getfetsel('email', "spip_auteurs", 'id_auteur=' . intval($row['id_auteur']));
 
 	// passage en centimes d'euros
-	$montant = intval(round(100*$row['montant']));
+	$montant = intval(round((10**$devise_defaut['fraction']) * $row['montant']));
 	if (strlen($montant)<10){
 		$montant = str_pad($montant, 10, '0', STR_PAD_LEFT);
 	}
@@ -76,7 +77,7 @@ function presta_paybox_call_directplus_dist($id_transaction, $transaction_hash, 
 	$parm['CLE'] = $config['DIRECT_PLUS_CLE'];
 	$parm['DATEQ'] = date('dmYHis');
 	$parm['TYPE'] = _PAYBOX_DIRECTPLUS_AUTHDEBIT_ABONNE;
-	$parm['DEVISE'] = "978";
+	$parm['DEVISE'] = (string)$devise_defaut['code_num'];
 	$parm['REFERENCE'] = intval($id_transaction);
 	$parm['ARCHIVAGE'] = intval($id_transaction);
 	$parm['DIFFERE'] = '000';

--- a/presta/paybox/call/request.php
+++ b/presta/paybox/call/request.php
@@ -60,7 +60,7 @@ function presta_paybox_call_request_dist($id_transaction, $transaction_hash, $co
 	$mail = bank_porteur_email($row);
 
 	// passage en centimes d'euros : round en raison des approximations de calcul de PHP
-	$montant = intval(round(100*$row['montant'], 0));
+	$montant = intval(round((10**$devise_defaut['fraction']) * $row['montant'], 0));
 	if (strlen($montant)<3){
 		$montant = str_pad($montant, 3, '0', STR_PAD_LEFT);
 	}
@@ -74,7 +74,7 @@ function presta_paybox_call_request_dist($id_transaction, $transaction_hash, $co
 
 	$parm['PBX_OUTPUT'] = "C"; // recuperer uniquement les hidden
 	$parm['PBX_LANGUE'] = "FRA";
-	$parm['PBX_DEVISE'] = "978";
+	$parm['PBX_DEVISE'] = (string)$devise_defaut['code_num'];
 	$parm['PBX_TOTAL'] = $montant;
 	$parm['PBX_PORTEUR'] = defined('_PBX_PORTEUR') ? _PBX_PORTEUR : $mail;
 	$parm['PBX_CMD'] = intval($id_transaction);
@@ -103,7 +103,7 @@ function presta_paybox_call_request_dist($id_transaction, $transaction_hash, $co
 			$decrire_echeance = charger_fonction("decrire_echeance", "abos", true)
 			AND $echeance = $decrire_echeance($id_transaction, false)){
 			if ($echeance['montant']>0){
-				$montant_echeance = str_pad(intval(round(100*$echeance['montant'])), 10, "0", STR_PAD_LEFT);
+				$montant_echeance = str_pad(intval(round((10**$devise_defaut['fraction']) * $echeance['montant'])), 10, "0", STR_PAD_LEFT);
 
 				// si plus d'une echeance initiale prevue on ne sait pas faire avec Paybox
 				if (isset($echeance['count_init']) AND $echeance['count_init']>1){

--- a/presta/paybox/inc/paybox.php
+++ b/presta/paybox/inc/paybox.php
@@ -398,7 +398,8 @@ function paybox_traite_reponse_transaction($config, $response){
 	// Ouf, le reglement a ete accepte
 
 	// on verifie que le montant est bon !
-	$montant_regle = $response['montant']/100;
+	$devise_defaut = bank_devise_defaut();
+	$montant_regle = $response['montant'] / (10**$devise_defaut['fraction']);
 	if ($montant_regle!=$row['montant']){
 		spip_log($t = "call_response : id_transaction $id_transaction, montant regle $montant_regle!=" . $row['montant'] . ":" . paybox_shell_args($response), $mode);
 		// on log ca dans un journal dedie

--- a/presta/paypal/inc/paypal.php
+++ b/presta/paypal/inc/paypal.php
@@ -155,7 +155,8 @@ function paypal_traite_response($config, $response){
 	sql_updateq("spip_transactions", $set, "id_transaction=" . intval($id_transaction));
 
 	// une monnaie est-elle bien indique (et en EUR) ?
-	if (!isset($response['mc_currency']) OR ($response['mc_currency']!='EUR')){
+	$devise_defaut = bank_devise_defaut();
+	if (!isset($response['mc_currency']) OR ($response['mc_currency'] != strtoupper($devise_defaut['code']))) {
 		return bank_transaction_echec($id_transaction,
 			array(
 				'mode' => $mode,

--- a/presta/paypal/payer/acte.html
+++ b/presta/paypal/payer/acte.html
@@ -25,7 +25,7 @@
 				<input type="hidden" name="amount" value="#MONTANT" />
 				<input type="hidden" name="no_note" value="1" />
 				<input type="hidden" name="business" value="#ENV{config/BUSINESS_USERNAME}" />
-				<input type="hidden" name="currency_code" value="EUR" />
+				<input type="hidden" name="currency_code" value="[(#VAL|bank_devise_defaut|table_valeur{code}|strtoupper)]" />
 				<input type="hidden" name="lc" value="FR" />
 				<input type="hidden" name="invoice" value="#ID_TRANSACTION-#TRANSACTION_HASH" />
 				<BOUCLE_profil(AUTEURS){id_auteur}>

--- a/presta/paypalexpress/inc/paypalexpress.php
+++ b/presta/paypalexpress/inc/paypalexpress.php
@@ -127,7 +127,8 @@ function bank_paypalexpress_order_init($config, $id_transaction, $url_confirm = 
 	portion of the URL that buyers will return to after authorizing payment
 	*/
 	$paymentAmount = $row['montant'];
-	$currencyCodeType = "EUR";
+	$devise_defaut = bank_devise_defaut();
+	$currencyCodeType = strtoupper($devise_defaut['code']);
 	$paymentType = "Sale";
 
 
@@ -241,7 +242,8 @@ function bank_paypalexpress_checkoutpayment($payerid, $config){
 	*/
 	$token = urlencode($_SESSION['token']);
 	$paymentAmount = $row['montant'];
-	$currencyCodeType = "EUR";
+	$devise_defaut = bank_devise_defaut();
+	$currencyCodeType = strtoupper($devise_defaut['code']);
 	$paymentType = "Sale";
 	$payerID = urlencode($_SESSION['payer_id']);
 	$serverName = urlencode($_SERVER['SERVER_NAME']);

--- a/presta/paypalexpress/lister_devises.php
+++ b/presta/paypalexpress/lister_devises.php
@@ -1,0 +1,9 @@
+<?php
+
+if (!defined('_ECRIRE_INC_VERSION')) {
+	return;
+}
+
+function presta_paypalexpress_lister_devises_dist() {
+	return array('AUD','BRL','CAD','CZK','DKK','EUR','HKD','HUF','INR','ILS','JPY','MYR','MXN','TWD','NZD','NOK','PHP','PLN','GBP','RUB','SGD','SEK','CHF','THB','USD');
+}

--- a/presta/simu/lister_devises.php
+++ b/presta/simu/lister_devises.php
@@ -1,0 +1,9 @@
+<?php
+
+if (!defined('_ECRIRE_INC_VERSION')) {
+	return;
+}
+
+function presta_simu_lister_devises_dist() {
+	return true;
+}

--- a/presta/sips/call/request.php
+++ b/presta/sips/call/request.php
@@ -26,6 +26,7 @@ if (!defined('_ECRIRE_INC_VERSION')){
  */
 function presta_sips_call_request_dist($id_transaction, $transaction_hash, $config){
 
+	$devise_defaut = bank_devise_defaut();
 	$mode = 'sips';
 	if (!is_array($config) OR !isset($config['type']) OR !isset($config['presta'])){
 		spip_log("call_request : config invalide " . var_export($config, true), $mode . _LOG_ERREUR);
@@ -49,7 +50,7 @@ function presta_sips_call_request_dist($id_transaction, $transaction_hash, $conf
 	$mail = bank_porteur_email($row);
 
 	// passage en centimes d'euros : round en raison des approximations de calcul de PHP
-	$montant = intval(round(100*$row['montant'], 0));
+	$montant = intval(round((10**$devise_defaut['fraction']) * $row['montant'], 0));
 
 	$merchant_id = $config['merchant_id'];
 	$service = $config['service'];
@@ -59,7 +60,7 @@ function presta_sips_call_request_dist($id_transaction, $transaction_hash, $conf
 	$parm = array();
 	$parm['merchant_id'] = $merchant_id;
 	$parm['merchant_country'] = "fr";
-	$parm['currency_code'] = "978";
+	$parm['currency_code'] = (string)$devise_defaut['code_num'];
 	$parm['amount'] = $montant;
 	$parm['customer_id'] = intval($row['id_auteur']) ? $row['id_auteur'] : $row['auteur_id'];
 	$parm['order_id'] = intval($id_transaction);

--- a/presta/sips/inc/sips.php
+++ b/presta/sips/inc/sips.php
@@ -309,7 +309,8 @@ function sips_traite_reponse_transaction($config, $response){
 	// Ouf, le reglement a ete accepte
 
 	// on verifie que le montant est bon !
-	$montant_regle = $response[($mode=='sipsabo' ? 'sub_' : '') . 'amount']/100;
+	$devise_defaut = bank_devise_defaut();
+	$montant_regle = $response[($mode=='sipsabo' ? 'sub_' : '') . 'amount'] / (10**$devise_defaut['fraction']);
 	if ($montant_regle!=$row['montant']){
 		spip_log($t = "call_response : id_transaction $id_transaction, montant regle $montant_regle!=" . $row['montant'] . ":" . sips_shell_args($response), $mode);
 		// on log ca dans un journal dedie

--- a/presta/sipsv2/call/request.php
+++ b/presta/sipsv2/call/request.php
@@ -29,7 +29,8 @@ function presta_sipsv2_call_request_dist($id_transaction, $transaction_hash, $co
 	include_spip('presta/sipsv2/inc/sipsv2');
 	$mode = 'sipsv2';
 	$logname = 'spipsvdeux';
-
+	$devise_defaut = bank_devise_defaut();
+	
 	if (!is_array($config) OR !isset($config['type']) OR !isset($config['presta'])){
 		spip_log("call_request : config invalide " . var_export($config, true), $logname . _LOG_ERREUR);
 		$mode = $config['presta'];
@@ -59,7 +60,7 @@ function presta_sipsv2_call_request_dist($id_transaction, $transaction_hash, $co
 	$mail = bank_porteur_email($row);
 
 	// passage en centimes d'euros : round en raison des approximations de calcul de PHP
-	$montant = intval(round(100*$row['montant'], 0));
+	$montant = intval(round((10**$devise_defaut['fraction']) * $row['montant'], 0));
 
 	list($merchant_id, $key_version, $secret_key) = sipsv2_key($config);
 	$service = $config['service'];
@@ -68,7 +69,7 @@ function presta_sipsv2_call_request_dist($id_transaction, $transaction_hash, $co
 	$parm = array();
 	$parm['merchantID'] = $merchant_id;
 	$parm['amount'] = $montant;
-	$parm['currencyCode'] = "978";
+	$parm['currencyCode'] = (string)$devise_defaut['code_num'];
 
 	$parm['customerId'] = intval($row['id_auteur']) ? $row['id_auteur'] : $row['auteur_id'];
 	$parm['orderId'] = intval($id_transaction);

--- a/presta/sipsv2/inc/sipsv2.php
+++ b/presta/sipsv2/inc/sipsv2.php
@@ -298,7 +298,8 @@ function sipsv2_traite_reponse_transaction($config, $response){
 	// Ouf, le reglement a ete accepte
 
 	// on verifie que le montant est bon !
-	$montant_regle = round($response['amount']/100, 2);
+	$devise_defaut = bank_devise_defaut();
+	$montant_regle = round($response['amount'] / (10**$devise_defaut['fraction']), 2);
 	if ($montant_regle!=$row['montant']){
 		spip_log($t = "call_response : id_transaction $id_transaction, montant regle $montant_regle!=" . $row['montant'] . ":" . bank_shell_args($response), $logname . _LOG_ERREUR);
 		// on log ca dans un journal dedie

--- a/presta/stripe/call/request.php
+++ b/presta/stripe/call/request.php
@@ -202,7 +202,7 @@ function presta_stripe_call_request_dist($id_transaction, $transaction_hash, $co
 	if ($type === 'abo' and $echeance){
 		if ($echeance['montant'] > 0) {
 
-			$montant_echeance = intval(round(100 * $echeance['montant'], 0));
+			$montant_echeance = intval(round((10**$devise_defaut['fraction']) * $echeance['montant'], 0));
 			if (strlen($montant_echeance) < 3) {
 				$montant_echeance = str_pad($montant_echeance, 3, '0', STR_PAD_LEFT);
 			}

--- a/presta/stripe/call/request.php
+++ b/presta/stripe/call/request.php
@@ -30,7 +30,7 @@ include_spip('presta/stripe/inc/stripe');
  * @return array
  */
 function presta_stripe_call_request_dist($id_transaction, $transaction_hash, $config, $type = "acte"){
-
+	$devise_defaut = bank_devise_defaut();
 	$mode = 'stripe';
 	if (!is_array($config) OR !isset($config['type']) OR !isset($config['presta'])){
 		spip_log("call_request : config invalide " . var_export($config, true), $mode . _LOG_ERREUR);
@@ -96,7 +96,7 @@ function presta_stripe_call_request_dist($id_transaction, $transaction_hash, $co
 	$email = $billing['email'];
 
 	// passage en centimes d'euros : round en raison des approximations de calcul de PHP
-	$montant = intval(round(100*$row['montant'], 0));
+	$montant = intval(round((10**$devise_defaut['fraction']) * $row['montant'], 0));
 	if (strlen($montant)<3){
 		$montant = str_pad($montant, 3, '0', STR_PAD_LEFT);
 	}
@@ -122,7 +122,7 @@ function presta_stripe_call_request_dist($id_transaction, $transaction_hash, $co
 	$contexte['action'] = str_replace('&', '&amp;', $url_success);
 	$contexte['email'] = $email;
 	$contexte['amount'] = $montant;
-	$contexte['currency'] = 'eur';
+	$contexte['currency'] = strtolower($devise_defaut['code']);
 	$contexte['key'] = ($config['mode_test'] ? $config['PUBLISHABLE_KEY_test'] : $config['PUBLISHABLE_KEY']);
 	$contexte['name'] = bank_nom_site();
 	$contexte['description'] = _T('bank:titre_transaction') . '#' . $id_transaction;

--- a/presta/stripe/inc/stripe.php
+++ b/presta/stripe/inc/stripe.php
@@ -270,7 +270,8 @@ function stripe_traite_reponse_transaction($config, &$response){
 	// Ouf, le reglement a ete accepte
 
 	// on verifie que le montant est bon !
-	$montant_regle = $payment->amount_received/100;
+	$devise_defaut = bank_devise_defaut();
+	$montant_regle = $payment->amount_received / (10**$devise_defaut['fraction']);
 
 	if ($montant_regle!=$row['montant']){
 		spip_log($t = "call_response : id_transaction $id_transaction, montant regle $montant_regle!=" . $row['montant'] . ":" . var_export($payment, true), $mode);

--- a/presta/stripe/lister_devises.php
+++ b/presta/stripe/lister_devises.php
@@ -1,0 +1,9 @@
+<?php
+
+if (!defined('_ECRIRE_INC_VERSION')) {
+	return;
+}
+
+function presta_stripe_lister_devises_dist() {
+	return array('USD','AED','AFN','ALL','AMD','ANG','AOA','ARS','AUD','AWG','AZN','BAM','BBD','BDT','BGN','BIF','BMD','BND','BOB','BRL','BSD','BWP','BZD','CAD','CDF','CHF','CLP','CNY','COP','CRC','CVE','CZK','DJF','DKK','DOP','DZD','EGP','ETB','EUR','FJD','FKP','GBP','GEL','GIP','GMD','GNF','GTQ','GYD','HKD','HNL','HRK','HTG','HUF','IDR','ILS','INR','ISK','JMD','JPY','KES','KGS','KHR','KMF','KRW','KYD','KZT','LAK','LBP','LKR','LRD','LSL','MAD','MDL','MGA','MKD','MMK','MNT','MOP','MRO','MUR','MVR','MWK','MXN','MYR','MZN','NAD','NGN','NIO','NOK','NPR','NZD','PAB','PEN','PGK','PHP','PKR','PLN','PYG','QAR','RON','RSD','RUB','RWF','SAR','SBD','SCR','SEK','SGD','SHP','SLL','SOS','SRD','STD','SZL','THB','TJS','TOP','TRY','TTD','TWD','TZS','UAH','UGX','UYU','UZS','VND','VUV','WST','XAF','XCD','XOF','XPF','YER','ZAR','ZMW');
+}

--- a/presta/systempay/call/request.php
+++ b/presta/systempay/call/request.php
@@ -110,8 +110,9 @@ function presta_systempay_call_request_dist($id_transaction, $transaction_hash, 
 	//$parm['vads_validation_mode'] = 0;
 
 	// passage en centimes d'euros : round en raison des approximations de calcul de PHP
-	$parm['vads_currency'] = 978;
-	$parm['vads_amount'] = intval(round(100*$row['montant'], 0));
+	$devise_defaut = bank_devise_defaut();
+	$parm['vads_currency'] = $devise_defaut['code_num'];
+	$parm['vads_amount'] = intval(round((10**$devise_defaut['fraction']) * $row['montant'], 0));
 
 	$parm['vads_language'] = $GLOBALS['spip_lang'];
 
@@ -199,7 +200,7 @@ function presta_systempay_call_request_dist($id_transaction, $transaction_hash, 
 				}
 
 				// montant de l'echeance
-				$parm['vads_sub_amount'] = intval(round(100*$echeance['montant'], 0));
+				$parm['vads_sub_amount'] = intval(round((10**$devise_defaut['fraction']) * $echeance['montant'], 0));
 				// meme devise que le paiement initial
 				$parm['vads_sub_currency'] = $parm['vads_currency'];
 
@@ -234,7 +235,7 @@ function presta_systempay_call_request_dist($id_transaction, $transaction_hash, 
 				if ($nb_init>0){
 					$parm['vads_sub_init_amount_number'] = $nb_init;
 					$parm['vads_sub_init_amount'] = $parm['vads_amount'];
-					if (isset($echeance['montant_init']) AND ($m = intval(round(100*$echeance['montant_init'], 0)))>0){
+					if (isset($echeance['montant_init']) AND ($m = intval(round((10**$devise_defaut['fraction']) * $echeance['montant_init'], 0)))>0){
 						$parm['vads_sub_init_amount'] = $m;
 					}
 				}

--- a/presta/systempay/inc/systempay.php
+++ b/presta/systempay/inc/systempay.php
@@ -378,7 +378,8 @@ function systempay_traite_reponse_transaction($config, $response){
 	if ($is_payment){
 		// Ouf, le reglement a ete accepte
 		// on verifie que le montant est bon !
-		$montant_regle = $response['vads_effective_amount']/100;
+		$devise_defaut = bank_devise_defaut();
+		$montant_regle = $response['vads_effective_amount'] / (10**$devise_defaut['fraction']);
 		if ($montant_regle!=$row['montant']){
 			spip_log($t = "call_response : id_transaction $id_transaction, montant regle $montant_regle!=" . $row['montant'] . ":" . bank_shell_args($response), $mode);
 			// on log ca dans un journal dedie


### PR DESCRIPTION
Cette PR permet de modifier la devise par défaut.

Une fonction est dédiée à la récupération de la devise par défaut, et continue de donner l'euro comme avant, mais c'est modifiable par pipeline. On doit fournir plusieurs informations : le code alpha, le code numérique, et l'arrondi. Avec cela on a toutes les informations nécessaires pour tous les prestataires.

Chaque prestataire est modifié dans un commit séparé, pour lui faire prendre en compte la devise par défaut. Une nouvelle fonction optionnelle permet dans un prestataire de lister les devises qu'il accepte, et c'est implémenté pour ceux connus. Sinon c'est toujours que l'euro uniquement comme avant, ce qui ne casse rien. On permet aussi de dire "tout" ce qui permet de pas avoir à connaitre la liste, pour la simu ou les chèques par ex.

Si un prestataire est activé tout bien configuré mais n'accepte pas la devise du moment, alors il n'est pas proposé dans le formulaire de paiement.

La fonction d'affichage est modifiée pour utiliser aussi le code de la devise par défaut.