### PR TITLE
Paramètre "transactionReference" à passer uniquement en mode Production

### DIFF
--- a/presta/sipsv2/call/request.php
+++ b/presta/sipsv2/call/request.php
@@ -72,7 +72,9 @@ function presta_sipsv2_call_request_dist($id_transaction, $transaction_hash, $co
 
 	$parm['customerId'] = intval($row['id_auteur']) ? $row['id_auteur'] : $row['auteur_id'];
 	$parm['orderId'] = intval($id_transaction);
-	$parm['transactionReference'] = bank_transaction_id($row);
+	if (!$config['mode_test']) {
+        	$parm['transactionReference'] = bank_transaction_id($row);
+    	}
 	//$parm['customerContact.email']=substr($mail,0,128);
 
 	$parm['normalReturnUrl'] = bank_url_api_retour($config, 'response');


### PR DESCRIPTION
Le paramètre "transactionReference" est auto-généré en mode test.
On teste donc la config pour que le paramètre passe uniquement en mode production.