### PR TITLE
Ajout de Clic&Pay pour les commerçants du Groupe Crédit du Nord 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Il peut aussi être complété par
     * seul le paiement à l'acte est implémenté, les nouveaux paiements récurrents ne sont plus possibles (TODO)
   * Suppression du prestataire Internet+ (code non maintenu, non testé en situation réelle depuis trop longtemps)
   * Passage a la plateforme Monetico au lieu de CMCIC (rien a reconfigurer, c'est un switch transparent)
+  * Ajout du prestataire Clic&Pay pour les commerçants du groupe Crédit du Nord qui supporte le paiement par SEPA pour les paiements uniques et les paiements récurrents, copie de Payzen
   
 * Version 3 du plugin
   * Nécessite SPIP 3.0+, compatible SPIP 3.1 et SPIP 3.2

--- a/presta/clicandpay/call/resilier_abonnement.php
+++ b/presta/clicandpay/call/resilier_abonnement.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ * Paiement Bancaire
+ * module de paiement bancaire multi prestataires
+ * stockage des transactions
+ *
+ * Auteurs :
+ * Cedric Morin, Nursit.com
+ * Lyra
+ * (c) 2012-2019 - Distribue sous licence GNU/GPL
+ *
+ */
+if (!defined('_ECRIRE_INC_VERSION')){
+	return;
+}
+
+include_spip('presta/clicandpay/inc/clicandpay');
+
+/**
+ * Jamais appele directement dans le plugin bank/
+ * mais par une eventuelle methode abos/resilier d'un plugin externe
+ *
+ * @param string $uid
+ * @param array|string $config
+ * @return bool
+ */
+function presta_clicandpay_call_resilier_abonnement_dist($uid, $config = 'clicandpay'){
+
+	include_spip('presta/clicandpay/lib/ws-v5/classes');
+
+	include_spip('presta/systempay/inc/systempay');
+	include_spip('inc/bank');
+
+	$trans = sql_fetsel("mode,pay_id", "spip_transactions", "abo_uid=" . sql_quote($uid) . " AND mode LIKE " . sql_quote($config . '%'), '', 'id_transaction', '0,1');
+
+	if (!is_array($config)){
+		$config = bank_config($trans['mode']);
+	}
+	$mode = $config['presta'];
+
+	$vads = new ClicandpayWSv5($config);
+
+	$response = new cancelSubscriptionResponse();
+	try {
+		$response = $vads->cancelSubscription($trans['pay_id'], $uid);
+	} catch (Exception $e) {
+		spip_log($s = "call_resilier_abonnement : erreur " . $e->getMessage(), $mode . _LOG_ERREUR);
+		return false;
+	}
+
+	if ($e = $response->cancelSubscriptionResult->commonResponse->responseCode){
+		spip_log($s = "call_resilier_abonnement $uid : erreur $e : " . $response->cancelSubscriptionResult->commonResponse->responseCodeDetail, $mode . _LOG_ERREUR);
+		// 33 : Invalid Subscription => on est donc bien desabonne
+		if ($e==33){
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	return true;
+}

--- a/presta/clicandpay/call/response.php
+++ b/presta/clicandpay/call/response.php
@@ -1,0 +1,31 @@
+<?php
+/*
+ * Paiement Bancaire
+ * module de paiement bancaire multi prestataires
+ * stockage des transactions
+ *
+ * Auteurs :
+ * Cedric Morin, Nursit.com
+ * (c) 2012-2019 - Distribue sous licence GNU/GPL
+ *
+ */
+if (!defined('_ECRIRE_INC_VERSION')){
+	return;
+}
+
+/**
+ * il faut avoir un id_transaction et un transaction_hash coherents
+ * pour se premunir d'une tentative d'appel exterieur
+ *
+ * Clic&Pay utilise le meme code que SystemPay, avec juste service=clicandpay dans la config
+ * mais il est presente comme un prestataire separe pour une meilleure lisibilite
+ *
+ * @param array $config
+ * @param null|array $response
+ * @return array
+ */
+function presta_clicandpay_call_response_dist($config, $response = null){
+
+	$call_response = charger_fonction("response", "presta/systempay/call");
+	return $call_response($config, $response);
+}

--- a/presta/clicandpay/config.php
+++ b/presta/clicandpay/config.php
@@ -29,7 +29,7 @@ if (!defined('_SYSTEMPAY_VERSION')){
 }
 
 
-function payzen_lister_cartes_config($c, $cartes = true){
+function clicandpay_lister_cartes_config($c, $cartes = true){
 	include_spip('inc/bank');
 	$config = array('presta' => 'clicandpay', 'type' => isset($c['type']) ? $c['type'] : 'acte', 'service' => 'clicandpay');
 
@@ -55,7 +55,7 @@ function payzen_lister_cartes_config($c, $cartes = true){
  * @param $id_transaction
  * @return mixed|string
  */
-function presta_payzen_titre_type_paiement_dist($mode, $id_transaction){
+function presta_clicandpay_titre_type_paiement_dist($mode, $id_transaction){
 
 	if ($id_transaction
 		AND $trans = sql_fetsel("refcb", "spip_transactions", "id_transaction=" . intval($id_transaction))

--- a/presta/clicandpay/config.php
+++ b/presta/clicandpay/config.php
@@ -1,0 +1,67 @@
+<?php
+/*
+ * Paiement Bancaire
+ * module de paiement bancaire multi prestataires
+ * stockage des transactions
+ *
+ * Auteurs :
+ * Cedric Morin, Nursit.com
+ * (c) 2012-2019 - Distribue sous licence GNU/GPL
+ * Lyra 
+ *
+ */
+if (!defined('_ECRIRE_INC_VERSION')){
+	return;
+}
+
+/* Clic&Pay  ----------------------------------------------------------- */
+
+
+/**
+ *
+ * Clic&Pay est fourni par LyraNetworks comme SystemPay dont il partage une grande partie du code
+ *
+ */
+
+# Version du logiciel
+if (!defined('_SYSTEMPAY_VERSION')){
+	define("_SYSTEMPAY_VERSION", "V2");
+}
+
+
+function payzen_lister_cartes_config($c, $cartes = true){
+	include_spip('inc/bank');
+	$config = array('presta' => 'clicandpay', 'type' => isset($c['type']) ? $c['type'] : 'acte', 'service' => 'clicandpay');
+
+	include_spip("presta/systempay/inc/systempay");
+	$liste = systempay_available_cards($config);
+
+	$others = array('SDD', 'E_CV');
+	foreach ($liste as $k => $v){
+		if ($cartes AND in_array($k, $others)){
+			unset($liste[$k]);
+		}
+		if (!$cartes AND !in_array($k, $others)){
+			unset($liste[$k]);
+		}
+	}
+	return $liste;
+}
+
+
+/**
+ * Titre "paiement SEPA" eventuel
+ * @param $mode
+ * @param $id_transaction
+ * @return mixed|string
+ */
+function presta_payzen_titre_type_paiement_dist($mode, $id_transaction){
+
+	if ($id_transaction
+		AND $trans = sql_fetsel("refcb", "spip_transactions", "id_transaction=" . intval($id_transaction))
+		AND strncmp($trans['refcb'], "SEPA", 4)==0){
+		return _T("bank:label_type_paiement_sepa", array('presta' => "ClicAndPay"));
+	}
+
+	return "";
+}

--- a/presta/clicandpay/inc-configurer.html
+++ b/presta/clicandpay/inc-configurer.html
@@ -1,0 +1,26 @@
+<input type="hidden" name="#ENV{casier,''}[service]" value="clicandpay" />
+<ul class="editer-groupe">
+	#SET{name,#ENV{casier,''}_SITE_ID}#SET{obli,''}#SET{defaut,''}#SET{erreurs,#ENV**{erreurs}|table_valeur{#GET{name}}}
+	<li class="editer editer_[(#GET{name})][ (#GET{obli})][ (#GET{erreurs}|oui)erreur]">
+		<label for="#GET{name}">ID</label>[
+		<span class='erreur_message'>(#GET{erreurs})</span>
+		]<input type="text" name="#ENV{casier,''}[SITE_ID]" class="text" value="[(#ENV*{#ENV{casier,''}}|table_valeur{SITE_ID,#GET{defaut}})]" id="#GET{name}" [(#HTML5|et{#GET{obli}})required='required']/>
+	</li>
+	#SET{name,#ENV{casier,''}_CLE}#SET{obli,''}#SET{defaut,''}#SET{erreurs,#ENV**{erreurs}|table_valeur{#GET{name}}}
+	<li class="editer editer_[(#GET{name})][ (#GET{obli})][ (#GET{erreurs}|oui)erreur]">
+		<label for="#GET{name}">CERTIFICAT (Production)</label>[
+		<span class='erreur_message'>(#GET{erreurs})</span>
+		]<input type="text" name="#ENV{casier,''}[CLE]" class="text" value="[(#ENV*{#ENV{casier,''}}|table_valeur{CLE,#GET{defaut}})]" id="#GET{name}" [(#HTML5|et{#GET{obli}})required='required']/>
+	</li>
+	<INCLURE{fond=formulaires/inc-bank-config-type,env} />
+	<INCLURE{fond=formulaires/inc-bank-config-cartes,env,cartes=#ENV{#ENV{casier,''}}|payzen_lister_cartes_config} />
+	<INCLURE{fond=formulaires/inc-bank-config-cartes,env,cartes=#ENV{#ENV{casier,''}}|payzen_lister_cartes_config{0},label=<:bank:label_configuration_autres_moyens:>} />
+	<INCLURE{fond=formulaires/inc-bank-config-mode_test,env} />
+	#SET{name,#ENV{casier,''}_CLE_test}#SET{obli,''}#SET{defaut,''}#SET{erreurs,#ENV**{erreurs}|table_valeur{#GET{name}}}
+	<li class="editer editer_[(#GET{name})][ (#GET{obli})][ (#GET{erreurs}|oui)erreur]">
+		<label for="#GET{name}">CERTIFICAT (Test)</label>[
+		<span class='erreur_message'>(#GET{erreurs})</span>
+		]<input type="text" name="#ENV{casier,''}[CLE_test]" class="text" value="[(#ENV*{#ENV{casier,''}}|table_valeur{CLE_test,#GET{defaut}})]" id="#GET{name}" [(#HTML5|et{#GET{obli}})required='required']/>
+	</li>
+</ul>
+<p class="explication">URL Serveur&nbsp;: <br /><input type="text" class="text" readonly="readonly" value="[(#ENV{#ENV{casier,''}}|bank_url_autoresponse)]" /></p>

--- a/presta/clicandpay/inc-configurer.html
+++ b/presta/clicandpay/inc-configurer.html
@@ -13,8 +13,8 @@
 		]<input type="text" name="#ENV{casier,''}[CLE]" class="text" value="[(#ENV*{#ENV{casier,''}}|table_valeur{CLE,#GET{defaut}})]" id="#GET{name}" [(#HTML5|et{#GET{obli}})required='required']/>
 	</li>
 	<INCLURE{fond=formulaires/inc-bank-config-type,env} />
-	<INCLURE{fond=formulaires/inc-bank-config-cartes,env,cartes=#ENV{#ENV{casier,''}}|payzen_lister_cartes_config} />
-	<INCLURE{fond=formulaires/inc-bank-config-cartes,env,cartes=#ENV{#ENV{casier,''}}|payzen_lister_cartes_config{0},label=<:bank:label_configuration_autres_moyens:>} />
+	<INCLURE{fond=formulaires/inc-bank-config-cartes,env,cartes=#ENV{#ENV{casier,''}}|clicandpay_lister_cartes_config} />
+	<INCLURE{fond=formulaires/inc-bank-config-cartes,env,cartes=#ENV{#ENV{casier,''}}|clicandpay_lister_cartes_config{0},label=<:bank:label_configuration_autres_moyens:>} />
 	<INCLURE{fond=formulaires/inc-bank-config-mode_test,env} />
 	#SET{name,#ENV{casier,''}_CLE_test}#SET{obli,''}#SET{defaut,''}#SET{erreurs,#ENV**{erreurs}|table_valeur{#GET{name}}}
 	<li class="editer editer_[(#GET{name})][ (#GET{obli})][ (#GET{erreurs}|oui)erreur]">

--- a/presta/clicandpay/inc-configurer_fonctions.php
+++ b/presta/clicandpay/inc-configurer_fonctions.php
@@ -1,0 +1,19 @@
+<?php
+/*
+ * Paiement Bancaire
+ * module de paiement bancaire multi prestataires
+ * stockage des transactions
+ *
+ * Auteurs :
+ * Cedric Morin, Nursit.com
+ * Lyra 
+ * (c) 2012-2019 - Distribue sous licence GNU/GPL
+ *
+ */
+if (!defined('_ECRIRE_INC_VERSION')){
+	return;
+}
+
+if (!function_exists('clicandpay_lister_cartes_config')){
+	include_spip('presta/clicandpay/config');
+}

--- a/presta/clicandpay/lib/ws-v5/classes.php
+++ b/presta/clicandpay/lib/ws-v5/classes.php
@@ -18,7 +18,7 @@ class ClicandpayWSv5 extends SoapClient {
 
 	public function ClicandpayWSv5(
 		$config,
-		$wsdl = "https://secure.payzen.eu/vads-ws/v5?wsdl",
+		$wsdl = "https://clicandpay.groupecdn.fr/vads-ws/v5?wsdl",
 		$options = array('trace' => 1, 'encoding' => 'UTF-8')){
 
 		$this->config = $config;
@@ -89,10 +89,10 @@ class ClicandpayWSv5 extends SoapClient {
 		$response = $this->__soapCall($method, $args);
 
 		/* logs XML*/
-		spip_log("[Request Header]\n".htmlspecialchars($this->__getLastRequestHeaders()),"payzen_ws"._LOG_DEBUG);
-		spip_log("[Request]\n".htmlspecialchars($this->__getLastRequest()),"payzen_ws"._LOG_DEBUG);
-		spip_log("[Response Header]\n".htmlspecialchars($this->__getLastResponseHeaders()),"payzen_ws"._LOG_DEBUG);
-		spip_log("[Response]\n".htmlspecialchars($this->__getLastResponse()),"payzen_ws"._LOG_DEBUG);
+		spip_log("[Request Header]\n".htmlspecialchars($this->__getLastRequestHeaders()),"clicandpay_ws"._LOG_DEBUG);
+		spip_log("[Request]\n".htmlspecialchars($this->__getLastRequest()),"clicandpay_ws"._LOG_DEBUG);
+		spip_log("[Response Header]\n".htmlspecialchars($this->__getLastResponseHeaders()),"clicandpay_ws"._LOG_DEBUG);
+		spip_log("[Response]\n".htmlspecialchars($this->__getLastResponse()),"clicandpay_ws"._LOG_DEBUG);
 
 
 		//Analyse de la réponse
@@ -115,7 +115,7 @@ class ClicandpayWSv5 extends SoapClient {
 		$authTokenResponse = base64_encode(hash_hmac('sha256', $responseHeader['timestamp'] . $responseHeader['requestId'], systempay_key($this->config), true));
 		if ($authTokenResponse!==$responseHeader['authToken']){
 			//Erreur de calcul ou tentative de fraude
-			spip_log("call_ws:$method: Erreur signature reponse","payzen_ws"._LOG_ERREUR);
+			spip_log("call_ws:$method: Erreur signature reponse","clicandpay_ws"._LOG_ERREUR);
 			return false;
 		}
 

--- a/presta/clicandpay/lib/ws-v5/classes.php
+++ b/presta/clicandpay/lib/ws-v5/classes.php
@@ -1,0 +1,914 @@
+<?php
+
+/**
+ * StandardWS class
+ *
+ *
+ *
+ * @author    {author}
+ * @copyright {copyright}
+ * @package   {package}
+ */
+class ClicandpayWSv5 extends SoapClient {
+
+	protected $header_namespace = "http://v5.ws.vads.lyra.com/Header/";
+	private $config = null;
+	private static $classmap = array(
+	);
+
+	public function ClicandpayWSv5(
+		$config,
+		$wsdl = "https://secure.payzen.eu/vads-ws/v5?wsdl",
+		$options = array('trace' => 1, 'encoding' => 'UTF-8')){
+
+		$this->config = $config;
+		foreach (self::$classmap as $key => $value){
+			if (!isset($options['classmap'][$key])){
+				$options['classmap'][$key] = $value;
+			}
+		}
+		parent::__construct($wsdl, $options);
+	}
+
+
+	/**
+	 * @return string
+	 */
+	public function gen_uuid(){
+		return sprintf('%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
+			mt_rand(0, 0xffff), mt_rand(0, 0xffff),
+			mt_rand(0, 0xffff),
+			mt_rand(0, 0x0fff) | 0x4000,
+			mt_rand(0, 0x3fff) | 0x8000,
+			mt_rand(0, 0xffff), mt_rand(0, 0xffff), mt_rand(0, 0xffff)
+		);
+	}
+
+	/**
+	 * @param $requestId
+	 * @param $timestamp
+	 * @param $key
+	 * @return string
+	 */
+	protected function getAuthToken($requestId, $timestamp, $key){
+		$data = $requestId . $timestamp;
+		$authToken = hash_hmac("sha256", $data, $key, true);
+		$authToken = base64_encode($authToken);
+		//var_dump($authToken);
+		return $authToken;
+	}
+
+	/**
+	 *
+	 */
+	protected function buildAuthHeader(){
+
+		$headers = array();
+
+		$uuid = $this->gen_uuid();
+		$timestamp = gmdate("Y-m-d\TH:i:s\Z");
+		$key = systempay_key($this->config);
+		$authToken = $this->getAuthToken($uuid, $timestamp, $key);
+
+		$headers[] = new SoapHeader($this->header_namespace,"shopId",$this->config['SITE_ID']);
+		$headers[] = new SoapHeader($this->header_namespace,"requestId",$uuid);
+		$headers[] = new SoapHeader($this->header_namespace,"timestamp",$timestamp);
+		$headers[] = new SoapHeader($this->header_namespace,"mode",$this->config['mode_test']?'TEST':'PRODUCTION');
+		$headers[] = new SoapHeader($this->header_namespace,"authToken",$authToken);
+
+		$this->__setSoapHeaders($headers);
+	}
+
+	/**
+	 * @param $method
+	 * @param $args
+	 * @return bool|mixed
+	 */
+	protected function call_ws($method,$args){
+		$this->buildAuthHeader();
+		$response = $this->__soapCall($method, $args);
+
+		/* logs XML*/
+		spip_log("[Request Header]\n".htmlspecialchars($this->__getLastRequestHeaders()),"payzen_ws"._LOG_DEBUG);
+		spip_log("[Request]\n".htmlspecialchars($this->__getLastRequest()),"payzen_ws"._LOG_DEBUG);
+		spip_log("[Response Header]\n".htmlspecialchars($this->__getLastResponseHeaders()),"payzen_ws"._LOG_DEBUG);
+		spip_log("[Response]\n".htmlspecialchars($this->__getLastResponse()),"payzen_ws"._LOG_DEBUG);
+
+
+		//Analyse de la réponse
+		//Récupération du SOAP Header de la réponse afin de stocker les en-têtes dans un tableau
+		// (ici $responseHeader)
+		$dom = new DOMDocument;
+		$dom->loadXML($this->__getLastResponse(), LIBXML_NOWARNING);
+		$path = new DOMXPath($dom);
+		$headers = $path->query('//*[local-name()="Header"]/*');
+		$responseHeader = array();
+		foreach ($headers as $headerItem){
+			$responseHeader[$headerItem->nodeName] = $headerItem->nodeValue;
+		}
+
+		#var_dump($responseHeader);
+		#var_dump($response);
+		#var_dump($response[$method."Result"]);
+
+		//Calcul du jeton d'authentification de la réponse
+		$authTokenResponse = base64_encode(hash_hmac('sha256', $responseHeader['timestamp'] . $responseHeader['requestId'], systempay_key($this->config), true));
+		if ($authTokenResponse!==$responseHeader['authToken']){
+			//Erreur de calcul ou tentative de fraude
+			spip_log("call_ws:$method: Erreur signature reponse","payzen_ws"._LOG_ERREUR);
+			return false;
+		}
+
+		return $response;
+	}
+
+	/**
+	 * @param $paymentToken
+	 * @param $subscriptionId
+	 * @return bool|mixed
+	 */
+	public function cancelSubscription($paymentToken, $subscriptionId){
+
+		//Génération du body
+		$commonRequest = new commonRequest();
+		$commonRequest->submissionDate = new DateTime('now', new DateTimeZone('UTC'));
+
+		$queryRequest = new queryRequest();
+		$queryRequest->paymentToken = $paymentToken;
+		$queryRequest->subscriptionId = $subscriptionId;
+
+		$cancelSubscription = new cancelSubscription();
+		$cancelSubscription->commonRequest = $commonRequest;
+		$cancelSubscription->queryRequest = $queryRequest;
+
+		return $this->call_ws('cancelSubscription', array($cancelSubscription));
+	}
+
+}
+
+
+class commonRequest {
+	public $paymentSource; // string
+	public $submissionDate; // dateTime
+	public $contractNumber; // string
+	public $comment; // string
+}
+
+class commonResponse {
+	public $responseCode; // int
+	public $responseCodeDetail; // string
+	public $transactionStatusLabel; // string
+	public $shopId; // string
+	public $paymentSource; // string
+	public $submissionDate; // dateTime
+	public $contractNumber; // string
+	public $paymentToken; // string
+}
+
+class cardRequest {
+	public $number; // string
+	public $scheme; // string
+	public $expiryMonth; // int
+	public $expiryYear; // int
+	public $cardSecurityCode; // string
+	public $cardHolderBirthDay; // dateTime
+	public $paymentToken; // string
+}
+
+class customerRequest {
+	public $billingDetails; // billingDetailsRequest
+	public $shippingDetails; // shippingDetailsRequest
+	public $extraDetails; // extraDetailsRequest
+}
+
+class billingDetailsRequest {
+	public $reference; // string
+	public $title; // string
+	public $type; // custStatus
+	public $firstName; // string
+	public $lastName; // string
+	public $phoneNumber; // string
+	public $email; // string
+	public $streetNumber; // string
+	public $address; // string
+	public $district; // string
+	public $zipCode; // string
+	public $city; // string
+	public $state; // string
+	public $country; // string
+	public $language; // string
+	public $cellPhoneNumber; // string
+	public $legalName; // string
+}
+
+class shippingDetailsRequest {
+	public $type; // custStatus
+	public $firstName; // string
+	public $lastName; // string
+	public $phoneNumber; // string
+	public $streetNumber; // string
+	public $address; // string
+	public $address2; // string
+	public $district; // string
+	public $zipCode; // string
+	public $city; // string
+	public $state; // string
+	public $country; // string
+	public $deliveryCompanyName; // string
+	public $shippingSpeed; // deliverySpeed
+	public $shippingMethod; // deliveryType
+	public $legalName; // string
+}
+
+class extraDetailsRequest {
+	public $ipAddress; // string
+}
+
+class paymentRequest {
+	public $transactionId; // string
+	public $amount; // long
+	public $currency; // int
+	public $expectedCaptureDate; // dateTime
+	public $manualValidation; // int
+	public $paymentOptionCode; // string
+}
+
+class paymentResponse {
+	public $transactionId; // string
+	public $amount; // long
+	public $currency; // int
+	public $effectiveAmount; // long
+	public $effectiveCurrency; // int
+	public $expectedCaptureDate; // dateTime
+	public $manualValidation; // int
+	public $operationType; // int
+	public $creationDate; // dateTime
+	public $externalTransactionId; // string
+	public $liabilityShift; // string
+	public $transactionUuid; // string
+}
+
+class orderResponse {
+	public $orderId; // string
+	public $extInfo; // extInfo
+}
+
+class extInfo {
+	public $key; // string
+	public $value; // string
+}
+
+class cardResponse {
+	public $number; // string
+	public $scheme; // string
+	public $brand; // string
+	public $country; // string
+	public $productCode; // string
+	public $bankCode; // string
+	public $expiryMonth; // int
+	public $expiryYear; // int
+}
+
+class authorizationResponse {
+	public $mode; // string
+	public $amount; // long
+	public $currency; // int
+	public $date; // dateTime
+	public $number; // string
+	public $result; // int
+}
+
+class captureResponse {
+	public $date; // dateTime
+	public $number; // int
+	public $reconciliationStatus; // int
+	public $refundAmount; // long
+	public $refundCurrency; // int
+}
+
+class customerResponse {
+	public $billingDetails; // billingDetailsResponse
+	public $shippingDetails; // shippingDetailsResponse
+	public $extraDetails; // extraDetailsResponse
+}
+
+class billingDetailsResponse {
+	public $reference; // string
+	public $title; // string
+	public $type; // custStatus
+	public $firstName; // string
+	public $lastName; // string
+	public $phoneNumber; // string
+	public $email; // string
+	public $streetNumber; // string
+	public $address; // string
+	public $district; // string
+	public $zipCode; // string
+	public $city; // string
+	public $state; // string
+	public $country; // string
+	public $language; // string
+	public $cellPhoneNumber; // string
+	public $legalName; // string
+}
+
+class shippingDetailsResponse {
+	public $type; // custStatus
+	public $firstName; // string
+	public $lastName; // string
+	public $phoneNumber; // string
+	public $streetNumber; // string
+	public $address; // string
+	public $address2; // string
+	public $district; // string
+	public $zipCode; // string
+	public $city; // string
+	public $state; // string
+	public $country; // string
+	public $deliveryCompanyName; // string
+	public $shippingSpeed; // deliverySpeed
+	public $shippingMethod; // deliveryType
+	public $legalName; // string
+}
+
+class extraDetailsResponse {
+	public $ipAddress; // string
+}
+
+class markResponse {
+	public $amount; // long
+	public $currency; // int
+	public $date; // dateTime
+	public $number; // string
+	public $result; // int
+}
+
+class threeDSResponse {
+	public $authenticationRequestData; // authenticationRequestData
+	public $authenticationResultData; // authenticationResultData
+}
+
+class authenticationRequestData {
+	public $threeDSAcctId; // string
+	public $threeDSAcsUrl; // string
+	public $threeDSBrand; // string
+	public $threeDSEncodedPareq; // string
+	public $threeDSEnrolled; // string
+	public $threeDSRequestId; // string
+}
+
+class authenticationResultData {
+	public $brand; // string
+	public $enrolled; // string
+	public $status; // string
+	public $eci; // string
+	public $xid; // string
+	public $cavv; // string
+	public $cavvAlgorithm; // string
+	public $signValid; // string
+	public $transactionCondition; // string
+}
+
+class extraResponse {
+	public $paymentOptionCode; // string
+	public $paymentOptionOccNumber; // int
+}
+
+class fraudManagementResponse {
+	public $riskControl; // riskControl
+	public $riskAnalysis; // riskAnalysis
+}
+
+class riskControl {
+	public $name; // string
+	public $result; // string
+}
+
+class riskAnalysis {
+	public $score; // string
+	public $resultCode; // string
+	public $status; // vadRiskAnalysisProcessingStatus
+	public $requestId; // string
+	public $extraInfo; // extInfo
+}
+
+class techRequest {
+	public $browserUserAgent; // string
+	public $browserAccept; // string
+}
+
+class orderRequest {
+	public $orderId; // string
+	public $extInfo; // extInfo
+}
+
+class createPayment {
+	public $commonRequest; // commonRequest
+	public $threeDSRequest; // threeDSRequest
+	public $paymentRequest; // paymentRequest
+	public $orderRequest; // orderRequest
+	public $cardRequest; // cardRequest
+	public $customerRequest; // customerRequest
+	public $techRequest; // techRequest
+}
+
+class threeDSRequest {
+	public $mode; // threeDSMode
+	public $requestId; // string
+	public $pares; // string
+	public $brand; // string
+	public $enrolled; // string
+	public $status; // string
+	public $eci; // string
+	public $xid; // string
+	public $cavv; // string
+	public $algorithm; // string
+}
+
+class createPaymentResponse {
+	public $createPaymentResult; // createPaymentResult
+}
+
+class createPaymentResult {
+	public $commonResponse; // commonResponse
+	public $paymentResponse; // paymentResponse
+	public $orderResponse; // orderResponse
+	public $cardResponse; // cardResponse
+	public $authorizationResponse; // authorizationResponse
+	public $captureResponse; // captureResponse
+	public $customerResponse; // customerResponse
+	public $markResponse; // markResponse
+	public $threeDSResponse; // threeDSResponse
+	public $extraResponse; // extraResponse
+	public $subscriptionResponse; // subscriptionResponse
+	public $fraudManagementResponse; // fraudManagementResponse
+}
+
+class cancelToken {
+	public $commonRequest; // commonRequest
+	public $queryRequest; // queryRequest
+}
+
+class cancelTokenResponse {
+	public $cancelTokenResult; // cancelTokenResult
+}
+
+class cancelTokenResult {
+	public $commonResponse; // commonResponse
+}
+
+class queryRequest {
+	public $uuid; // string
+	public $orderId; // string
+	public $subscriptionId; // string
+	public $paymentToken; // string
+}
+
+class wsResponse {
+	public $requestId; // string
+}
+
+class createToken {
+	public $commonRequest; // commonRequest
+	public $cardRequest; // cardRequest
+	public $customerRequest; // customerRequest
+}
+
+class createTokenResponse {
+	public $createTokenResult; // createTokenResult
+}
+
+class createTokenResult {
+	public $commonResponse; // commonResponse
+	public $paymentResponse; // paymentResponse
+	public $orderResponse; // orderResponse
+	public $cardResponse; // cardResponse
+	public $authorizationResponse; // authorizationResponse
+	public $captureResponse; // captureResponse
+	public $customerResponse; // customerResponse
+	public $markResponse; // markResponse
+	public $threeDSResponse; // threeDSResponse
+	public $extraResponse; // extraResponse
+	public $subscriptionResponse; // subscriptionResponse
+	public $fraudManagementResponse; // fraudManagementResponse
+}
+
+class subscriptionResponse {
+	public $subscriptionId; // string
+	public $effectDate; // dateTime
+	public $cancelDate; // dateTime
+	public $initialAmount; // long
+	public $rrule; // string
+	public $description; // string
+	public $initialAmountNumber; // int
+	public $pastPaymentNumber; // int
+	public $totalPaymentNumber; // int
+	public $amount; // long
+	public $currency; // int
+}
+
+class getTokenDetails {
+	public $queryRequest; // queryRequest
+}
+
+class getTokenDetailsResponse {
+	public $getTokenDetailsResult; // getTokenDetailsResult
+}
+
+class getTokenDetailsResult {
+	public $commonResponse; // commonResponse
+	public $paymentResponse; // paymentResponse
+	public $orderResponse; // orderResponse
+	public $cardResponse; // cardResponse
+	public $authorizationResponse; // authorizationResponse
+	public $captureResponse; // captureResponse
+	public $customerResponse; // customerResponse
+	public $markResponse; // markResponse
+	public $subscriptionResponse; // subscriptionResponse
+	public $extraResponse; // extraResponse
+	public $fraudManagementResponse; // fraudManagementResponse
+	public $threeDSResponse; // threeDSResponse
+}
+
+class updateSubscription {
+	public $commonRequest; // commonRequest
+	public $queryRequest; // queryRequest
+	public $subscriptionRequest; // subscriptionRequest
+}
+
+class subscriptionRequest {
+	public $subscriptionId; // string
+	public $effectDate; // dateTime
+	public $amount; // long
+	public $currency; // int
+	public $initialAmount; // long
+	public $initialAmountNumber; // int
+	public $rrule; // string
+	public $description; // string
+}
+
+class updateSubscriptionResponse {
+	public $updateSubscriptionResult; // updateSubscriptionResult
+}
+
+class updateSubscriptionResult {
+	public $commonResponse; // commonResponse
+	public $paymentResponse; // paymentResponse
+	public $orderResponse; // orderResponse
+	public $cardResponse; // cardResponse
+	public $authorizationResponse; // authorizationResponse
+	public $captureResponse; // captureResponse
+	public $customerResponse; // customerResponse
+	public $markResponse; // markResponse
+	public $threeDSResponse; // threeDSResponse
+	public $extraResponse; // extraResponse
+	public $subscriptionResponse; // subscriptionResponse
+	public $fraudManagementResponse; // fraudManagementResponse
+}
+
+class capturePayment {
+	public $settlementRequest; // settlementRequest
+}
+
+class settlementRequest {
+	public $transactionIds; // string
+	public $commission; // double
+	public $date; // dateTime
+}
+
+class capturePaymentResponse {
+	public $capturePaymentResult; // capturePaymentResult
+}
+
+class capturePaymentResult {
+	public $commonResponse; // commonResponse
+}
+
+class findPayments {
+	public $queryRequest; // queryRequest
+}
+
+class findPaymentsResponse {
+	public $findPaymentsResult; // findPaymentsResult
+}
+
+class findPaymentsResult {
+	public $commonResponse; // commonResponse
+	public $orderResponse; // orderResponse
+	public $transactionItem; // transactionItem
+}
+
+class transactionItem {
+	public $transactionUuid; // string
+	public $transactionStatusLabel; // string
+	public $amount; // long
+	public $currency; // int
+	public $expectedCaptureDate; // dateTime
+}
+
+class refundPayment {
+	public $commonRequest; // commonRequest
+	public $paymentRequest; // paymentRequest
+	public $queryRequest; // queryRequest
+}
+
+class refundPaymentResponse {
+	public $refundPaymentResult; // refundPaymentResult
+}
+
+class refundPaymentResult {
+	public $commonResponse; // commonResponse
+	public $paymentResponse; // paymentResponse
+	public $orderResponse; // orderResponse
+	public $cardResponse; // cardResponse
+	public $authorizationResponse; // authorizationResponse
+	public $captureResponse; // captureResponse
+	public $customerResponse; // customerResponse
+	public $markResponse; // markResponse
+	public $threeDSResponse; // threeDSResponse
+	public $extraResponse; // extraResponse
+	public $fraudManagementResponse; // fraudManagementResponse
+}
+
+class verifyThreeDSEnrollment {
+	public $commonRequest; // commonRequest
+	public $paymentRequest; // paymentRequest
+	public $cardRequest; // cardRequest
+	public $techRequest; // techRequest
+}
+
+class verifyThreeDSEnrollmentResponse {
+	public $verifyThreeDSEnrollmentResult; // verifyThreeDSEnrollmentResult
+}
+
+class verifyThreeDSEnrollmentResult {
+	public $commonResponse; // commonResponse
+	public $threeDSResponse; // threeDSResponse
+}
+
+class reactivateToken {
+	public $queryRequest; // queryRequest
+}
+
+class reactivateTokenResponse {
+	public $reactivateTokenResult; // reactivateTokenResult
+}
+
+class reactivateTokenResult {
+	public $commonResponse; // commonResponse
+}
+
+class createSubscription {
+	public $commonRequest; // commonRequest
+	public $orderRequest; // orderRequest
+	public $subscriptionRequest; // subscriptionRequest
+	public $cardRequest; // cardRequest
+}
+
+class createSubscriptionResponse {
+	public $createSubscriptionResult; // createSubscriptionResult
+}
+
+class createSubscriptionResult {
+	public $commonResponse; // commonResponse
+	public $paymentResponse; // paymentResponse
+	public $orderResponse; // orderResponse
+	public $cardResponse; // cardResponse
+	public $authorizationResponse; // authorizationResponse
+	public $captureResponse; // captureResponse
+	public $customerResponse; // customerResponse
+	public $markResponse; // markResponse
+	public $threeDSResponse; // threeDSResponse
+	public $extraResponse; // extraResponse
+	public $subscriptionResponse; // subscriptionResponse
+	public $fraudManagementResponse; // fraudManagementResponse
+}
+
+class cancelSubscription {
+	public $commonRequest; // commonRequest
+	public $queryRequest; // queryRequest
+}
+
+class cancelSubscriptionResponse {
+	public $cancelSubscriptionResult; // cancelSubscriptionResult
+}
+
+class cancelSubscriptionResult {
+	public $commonResponse; // commonResponse
+}
+
+class updatePayment {
+	public $commonRequest; // commonRequest
+	public $queryRequest; // queryRequest
+	public $paymentRequest; // paymentRequest
+}
+
+class updatePaymentResponse {
+	public $updatePaymentResult; // updatePaymentResult
+}
+
+class updatePaymentResult {
+	public $commonResponse; // commonResponse
+	public $paymentResponse; // paymentResponse
+	public $orderResponse; // orderResponse
+	public $cardResponse; // cardResponse
+	public $authorizationResponse; // authorizationResponse
+	public $captureResponse; // captureResponse
+	public $customerResponse; // customerResponse
+	public $markResponse; // markResponse
+	public $threeDSResponse; // threeDSResponse
+	public $extraResponse; // extraResponse
+	public $subscriptionResponse; // subscriptionResponse
+	public $fraudManagementResponse; // fraudManagementResponse
+}
+
+class validatePayment {
+	public $commonRequest; // commonRequest
+	public $queryRequest; // queryRequest
+}
+
+class validatePaymentResponse {
+	public $validatePaymentResult; // validatePaymentResult
+}
+
+class validatePaymentResult {
+	public $commonResponse; // commonResponse
+}
+
+class cancelPayment {
+	public $commonRequest; // commonRequest
+	public $queryRequest; // queryRequest
+}
+
+class cancelPaymentResponse {
+	public $cancelPaymentResult; // cancelPaymentResult
+}
+
+class cancelPaymentResult {
+	public $commonResponse; // commonResponse
+}
+
+class checkThreeDSAuthentication {
+	public $commonRequest; // commonRequest
+	public $threeDSRequest; // threeDSRequest
+}
+
+class checkThreeDSAuthenticationResponse {
+	public $checkThreeDSAuthenticationResult; // checkThreeDSAuthenticationResult
+}
+
+class checkThreeDSAuthenticationResult {
+	public $commonResponse; // commonResponse
+	public $threeDSResponse; // threeDSResponse
+}
+
+class getPaymentDetails {
+	public $queryRequest; // queryRequest
+}
+
+class getPaymentDetailsResponse {
+	public $getPaymentDetailsResult; // getPaymentDetailsResult
+}
+
+class getPaymentDetailsResult {
+	public $commonResponse; // commonResponse
+	public $paymentResponse; // paymentResponse
+	public $orderResponse; // orderResponse
+	public $cardResponse; // cardResponse
+	public $authorizationResponse; // authorizationResponse
+	public $captureResponse; // captureResponse
+	public $customerResponse; // customerResponse
+	public $markResponse; // markResponse
+	public $subscriptionResponse; // subscriptionResponse
+	public $extraResponse; // extraResponse
+	public $fraudManagementResponse; // fraudManagementResponse
+	public $threeDSResponse; // threeDSResponse
+}
+
+class duplicatePayment {
+	public $commonRequest; // commonRequest
+	public $paymentRequest; // paymentRequest
+	public $orderRequest; // orderRequest
+	public $queryRequest; // queryRequest
+}
+
+class duplicatePaymentResponse {
+	public $duplicatePaymentResult; // duplicatePaymentResult
+}
+
+class duplicatePaymentResult {
+	public $commonResponse; // commonResponse
+	public $paymentResponse; // paymentResponse
+	public $orderResponse; // orderResponse
+	public $cardResponse; // cardResponse
+	public $authorizationResponse; // authorizationResponse
+	public $captureResponse; // captureResponse
+	public $customerResponse; // customerResponse
+	public $markResponse; // markResponse
+	public $threeDSResponse; // threeDSResponse
+	public $extraResponse; // extraResponse
+	public $fraudManagementResponse; // fraudManagementResponse
+}
+
+class updateToken {
+	public $commonRequest; // commonRequest
+	public $queryRequest; // queryRequest
+	public $cardRequest; // cardRequest
+	public $customerRequest; // customerRequest
+}
+
+class updateTokenResponse {
+	public $updateTokenResult; // updateTokenResult
+}
+
+class updateTokenResult {
+	public $commonResponse; // commonResponse
+	public $paymentResponse; // paymentResponse
+	public $orderResponse; // orderResponse
+	public $cardResponse; // cardResponse
+	public $authorizationResponse; // authorizationResponse
+	public $captureResponse; // captureResponse
+	public $customerResponse; // customerResponse
+	public $markResponse; // markResponse
+	public $threeDSResponse; // threeDSResponse
+	public $extraResponse; // extraResponse
+	public $subscriptionResponse; // subscriptionResponse
+	public $fraudManagementResponse; // fraudManagementResponse
+}
+
+class getPaymentUuid {
+	public $legacyTransactionKeyRequest; // legacyTransactionKeyRequest
+}
+
+class legacyTransactionKeyRequest {
+	public $transactionId; // string
+	public $sequenceNumber; // int
+	public $creationDate; // dateTime
+}
+
+class getPaymentUuidResponse {
+	public $legacyTransactionKeyResult; // legacyTransactionKeyResult
+}
+
+class legacyTransactionKeyResult {
+	public $commonResponse; // commonResponse
+	public $paymentResponse; // paymentResponse
+}
+
+class getSubscriptionDetails {
+	public $queryRequest; // queryRequest
+}
+
+class getSubscriptionDetailsResponse {
+	public $getSubscriptionDetailsResult; // getSubscriptionDetailsResult
+}
+
+class getSubscriptionDetailsResult {
+	public $commonResponse; // commonResponse
+	public $paymentResponse; // paymentResponse
+	public $orderResponse; // orderResponse
+	public $cardResponse; // cardResponse
+	public $authorizationResponse; // authorizationResponse
+	public $captureResponse; // captureResponse
+	public $customerResponse; // customerResponse
+	public $markResponse; // markResponse
+	public $subscriptionResponse; // subscriptionResponse
+	public $extraResponse; // extraResponse
+	public $fraudManagementResponse; // fraudManagementResponse
+	public $threeDSResponse; // threeDSResponse
+}
+
+class custStatus {
+	const _PRIVATE = 'PRIVATE';
+	const COMPANY = 'COMPANY';
+}
+
+class deliverySpeed {
+	const STANDARD = 'STANDARD';
+	const EXPRESS = 'EXPRESS';
+}
+
+class deliveryType {
+	const RECLAIM_IN_SHOP = 'RECLAIM_IN_SHOP';
+	const RELAY_POINT = 'RELAY_POINT';
+	const RECLAIM_IN_STATION = 'RECLAIM_IN_STATION';
+	const PACKAGE_DELIVERY_COMPANY = 'PACKAGE_DELIVERY_COMPANY';
+	const ETICKET = 'ETICKET';
+}
+
+class vadRiskAnalysisProcessingStatus {
+	const P_TO_SEND = 'P_TO_SEND';
+	const P_SEND_KO = 'P_SEND_KO';
+	const P_PENDING_AT_ANALYZER = 'P_PENDING_AT_ANALYZER';
+	const P_SEND_OK = 'P_SEND_OK';
+	const P_MANUAL = 'P_MANUAL';
+	const P_SKIPPED = 'P_SKIPPED';
+	const P_SEND_EXPIRED = 'P_SEND_EXPIRED';
+}
+
+class threeDSMode {
+	const DISABLED = 'DISABLED';
+	const ENABLED_CREATE = 'ENABLED_CREATE';
+	const ENABLED_FINALIZE = 'ENABLED_FINALIZE';
+	const MERCHANT_3DS = 'MERCHANT_3DS';
+}

--- a/presta/clicandpay/lib/ws-v5/functions.php
+++ b/presta/clicandpay/lib/ws-v5/functions.php
@@ -1,0 +1,89 @@
+<?php
+
+function setHeaders($shopId, $requestId, $timestamp, $mode, $authToken, $key, $client){
+//Création des en-têtes shopId, requestId, timestamp, mode et authToken
+	$ns = 'http://v5.ws.vads.lyra.com/Header/';
+	$headerShopId = new SOAPHeader ($ns, 'shopId', $shopId);
+	$headerRequestId = new SOAPHeader ($ns, 'requestId', $requestId);
+	$headerTimestamp = new SOAPHeader ($ns, 'timestamp', $timestamp);
+	$headerMode = new SOAPHeader ($ns, 'mode', $mode);
+	$authToken = getAuthToken($requestId, $timestamp, $key);
+	$headerAuthToken = new SOAPHeader ($ns, 'authToken', $authToken);
+//Ajout des en-têtes dans le SOAP Header
+	$headers = array(
+		$headerShopId,
+		$headerRequestId,
+		$headerTimestamp,
+		$headerMode,
+		$headerAuthToken
+	);
+	$client->__setSoapHeaders($headers);
+}
+
+function setJsessionId($client){
+	$cookie = $_SESSION['JSESSIONID'];
+	$client->__setCookie('JSESSIONID', $cookie);
+	return $cookie;
+}
+
+/**
+ *
+ *
+ * @param $client
+ * @return string $JSESSIONID
+ */
+function getJsessionId($client){
+//récupération de l'entête de la réponse
+	$header = ($client->__getLastResponseHeaders());
+	if (!preg_match("#JSESSIONID=([A-Za-z0-9\._]+)#", $header, $matches)){
+		return "Aucun ID de Session Renvoyé."; //Ce cas ne devrait jamais se présenter;
+		die;
+	}
+	$JSESSIONID = $matches[1];
+	$_SESSION['JSESSIONID'] = $JSESSIONID;
+//print_r($JSESSIONID);
+	return $JSESSIONID;
+}
+
+function formConstructor($threeDsAcsUrl, $threeDSrequestId, $threeDsEncodedPareq,
+                         $threeDsServerResponseUrl){
+	$msg = ('
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr" lang="fr">
+<head>
+<meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
+<title>3DS</title>
+<script type="text/javascript">
+<!--
+function submitForm(){
+document.redirectForm.submit();
+}
+-->
+</script>
+</head>
+<body id="lyra" onLoad="setTimeout(\'submitForm()' . '\',500);">
+<div id="container">
+<div id="paymentSolutionInfo">
+<div id="title">&nbsp;</div>
+</div>
+<hr class="ensureDivHeight"/>
+<br/>
+<br/>
+<br/>
+<br/>
+<br/>
+<form name="redirectForm" action="' . $threeDsAcsUrl . '" method="POST">
+<input type="hidden" name="PaReq" value="' . $threeDsEncodedPareq . '"/>
+<input type="hidden" name="TermUrl" value="' . $threeDsServerResponseUrl . '"/>
+<input type="hidden" name="MD" value="' . $threeDSrequestId . '"/>
+<noscript><input type="submit" name="Go" value="Click to continue"/></noscript>
+</form>
+<div id="backToBoutiqueBlock"> </div>
+<div id="footer"> </div>
+</div>
+</body>
+</html>'
+	);
+	echo $msg;
+}

--- a/presta/clicandpay/payer/abonnement.html
+++ b/presta/clicandpay/payer/abonnement.html
@@ -1,0 +1,40 @@
+[(#REM)
+/*
+ * Paiement Bancaire
+ * module de paiement bancaire multi prestataires
+ * stockage des transactions
+ *
+ * Auteurs :
+ * Cedric Morin, Nursit.com
+ * Lyra
+ * (c) 2012-2019 - Distribue sous licence GNU/GPL
+ *
+ */
+]#CACHE{0}
+<BOUCLE_trans(TRANSACTIONS){id_transaction}{transaction_hash}>
+<B_cb>
+<div class='payer_mode payer_clicandpay payer_abonnement'>
+	<h4 class="titre h4"><:bank:abonnement_par_carte_bancaire:></h4>
+	[<p class="explication">(#ENV{config/presta}|bank_explication_mode_paiement)</p>]
+	<div class='boutons'>
+	<BOUCLE_cb(POUR){tableau #ENV{hidden}}{cle !IN SDD,E_CV}>
+		[(#INCLURE{fond=presta/systempay/payer/inc-choix-paiement,env,hidden=#VALEUR*,brand=#CLE*,logobrand=[(#VAL{clicandpay}|bank_trouver_logo{#ENV{logo}|table_valeur{#CLE}}|balise_img{[(#CLE|bank_label_payer_par_carte)]}|inserer_attribut{title,[(#CLE|bank_label_payer_par_carte)]})]})]
+	</BOUCLE_cb>
+	</div>
+	[(#ENV{sandbox}|oui)<div class="info"><:bank:info_mode_test{presta=PlicAndPay}:></div>]
+</div>
+</B_cb>
+<B_sepa>
+<div class='payer_mode payer_clicandpay payer_sepa payer_abonnement'>
+	<h4 class="titre h4"><:bank:abonnement_par_prelevement_sepa:></h4>
+	[<p class="explication">(#ENV{config/presta}|concat{_sepa}|bank_explication_mode_paiement)</p>]
+	<p class="explication"><:bank:info_prelevement_sepa{presta=ClicAndPay}:></p>
+	<div class='boutons'>
+	<BOUCLE_sepa(POUR){tableau #ENV{hidden}}{cle=SDD}>
+		[(#INCLURE{fond=presta/systempay/payer/inc-choix-paiement,env,hidden=#VALEUR*,brand=#CLE*,logobrand=[(#VAL{clicandpay}|bank_trouver_logo{#ENV{logo}|table_valeur{#CLE}}|bank_label_bouton_img_ou_texte{[(#CLE|bank_label_payer_par_carte)]})]})]
+	</BOUCLE_sepa>
+	</div>
+	[(#ENV{sandbox}|oui)<div class="info"><:bank:info_mode_test{presta=ClicAndPay}:></div>]
+</div>
+</B_sepa>
+</BOUCLE_trans>

--- a/presta/clicandpay/payer/abonnement.php
+++ b/presta/clicandpay/payer/abonnement.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ * Paiement Bancaire
+ * module de paiement bancaire multi prestataires
+ * stockage des transactions
+ *
+ * Auteurs :
+ * Cedric Morin, Nursit.com
+ * Lyra
+ * (c) 2012-2019 - Distribue sous licence GNU/GPL
+ *
+ */
+if (!defined('_ECRIRE_INC_VERSION')){
+	return;
+}
+
+
+/**
+ * @param array $config
+ * @param int $id_transaction
+ * @param string $transaction_hash
+ * @param array $options
+ * @return array|string
+ */
+function presta_clicandpay_payer_abonnement_dist($config, $id_transaction, $transaction_hash, $options = array()){
+
+	$call_request = charger_fonction('request', 'presta/systempay/call');
+
+	// Tip : pour tester les workflow de paiement abonnement decomposes avec les CB
+	// utiliser ici REGISTER_SUBSCRIBE au lieu de REGISTER_PAY_SUBSCRIBE
+	// cela permet d'avoir un premier hit sans paiement puis un hit du paiement dans l'heure (arrivera 13j apres en SEPA)
+	$contexte = $call_request($id_transaction, $transaction_hash, $config, "REGISTER_PAY_SUBSCRIBE");
+
+	$contexte['sandbox'] = ($config['mode_test'] ? ' ' : '');
+	$contexte['config'] = $config;
+
+	$contexte = array_merge($options, $contexte);
+
+	return recuperer_fond('presta/clicandpay/payer/abonnement', $contexte);
+}

--- a/presta/clicandpay/payer/acte.html
+++ b/presta/clicandpay/payer/acte.html
@@ -1,0 +1,52 @@
+[(#REM)
+/*
+ * Paiement Bancaire
+ * module de paiement bancaire multi prestataires
+ * stockage des transactions
+ *
+ * Auteurs :
+ * Cedric Morin, Nursit.com
+ * Lyra
+ * (c) 2012-2019 - Distribue sous licence GNU/GPL
+ *
+ */
+]#CACHE{0}
+<BOUCLE_trans(TRANSACTIONS){id_transaction}{transaction_hash}>
+<B_cb>
+<div class='payer_mode payer_clicandpay payer_acte'>
+	<h4 class="titre h4"><:bank:payer_par_carte_bancaire:></h4>
+	[<p class="explication">(#ENV{config/presta}|bank_explication_mode_paiement)</p>]
+	<div class='boutons'>
+	<BOUCLE_cb(POUR){tableau #ENV{hidden}}{cle !IN SDD,E_CV}>
+		[(#INCLURE{fond=presta/systempay/payer/inc-choix-paiement,env,hidden=#VALEUR*,brand=#CLE*,logobrand=[(#VAL{clicandpay}|bank_trouver_logo{#ENV{logo}|table_valeur{#CLE}}|balise_img{[(#CLE|bank_label_payer_par_carte)]}|inserer_attribut{title,[(#CLE|bank_label_payer_par_carte)]})]})]
+	</BOUCLE_cb>
+	</div>
+	[(#ENV{sandbox}|oui)<div class="info"><:bank:info_mode_test{presta=ClicAndPay}:></div>]
+</div>
+</B_cb>
+<B_sepa>
+<div class='payer_mode payer_clicandpay payer_sepa payer_acte'>
+	<h4 class="titre h4"><:bank:payer_par_prelevement_sepa:></h4>
+	[<p class="explication">(#ENV{config/presta}|concat{_sepa}|bank_explication_mode_paiement)</p>]
+	<div class='boutons'>
+	<BOUCLE_sepa(POUR){tableau #ENV{hidden}}{cle=SDD}>
+		[(#INCLURE{fond=presta/systempay/payer/inc-choix-paiement,env,hidden=#VALEUR*,brand=#CLE*,logobrand=[(#VAL{clicandpay}|bank_trouver_logo{#ENV{logo}|table_valeur{#CLE}}|bank_label_bouton_img_ou_texte{[(#CLE|bank_label_payer_par_carte)]})]})]
+	</BOUCLE_sepa>
+	</div>
+	[(#ENV{sandbox}|oui)<div class="info"><:bank:info_mode_test{presta=ClicAndPay}:></div>]
+</div>
+</B_sepa>
+<B_ecv>
+<div class='payer_mode payer_clicandpay payer_ecv payer_acte'>
+	<h4 class="titre h4"><:bank:payer_par_e_cheque_vacances:></h4>
+	[<p class="explication">(#ENV{config/presta}|concat{_ecv}|bank_explication_mode_paiement)</p>]
+	<div class='boutons'>
+	<BOUCLE_ecv(POUR){tableau #ENV{hidden}}{cle=E_CVxx}>
+		[(#INCLURE{fond=presta/systempay/payer/inc-choix-paiement,env,hidden=#VALEUR*,brand=#CLE*,logobrand=[(#VAL{clicandpay}|bank_trouver_logo{#ENV{logo}|table_valeur{#CLE}}||bank_label_bouton_img_ou_texte{[(#CLE|bank_label_payer_par_carte)]})]})]
+	</BOUCLE_ecv>
+	</div>
+	[(#ENV{sandbox}|oui)<div class="info"><:bank:info_mode_test{presta=ClicAndPay}:></div>]
+</div>
+</B_ecv>
+
+</BOUCLE_trans>

--- a/presta/clicandpay/payer/acte.php
+++ b/presta/clicandpay/payer/acte.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * Paiement Bancaire
+ * module de paiement bancaire multi prestataires
+ * stockage des transactions
+ *
+ * Auteurs :
+ * Cedric Morin, Nursit.com
+ * Lyra
+ * (c) 2012-2019 - Distribue sous licence GNU/GPL
+ *
+ */
+if (!defined('_ECRIRE_INC_VERSION')){
+	return;
+}
+
+
+/**
+ * @param array $config
+ * @param int $id_transaction
+ * @param string $transaction_hash
+ * @param array $options
+ * @return array|string
+ */
+function presta_clicandpay_payer_acte_dist($config, $id_transaction, $transaction_hash, $options = array()){
+
+	$call_request = charger_fonction('request', 'presta/systempay/call');
+	$contexte = $call_request($id_transaction, $transaction_hash, $config);
+
+	$contexte['sandbox'] = ($config['mode_test'] ? ' ' : '');
+	$contexte['config'] = $config;
+
+	$contexte = array_merge($options, $contexte);
+
+	return recuperer_fond('presta/clicandpay/payer/acte', $contexte);
+}

--- a/presta/clicandpay/readme.md
+++ b/presta/clicandpay/readme.md
@@ -1,0 +1,12 @@
+Clic&Pay est la solution de paiement pour les banques du Groupe Crédit du Nord : 
+- Crédit du Nord
+- Banque Courtois
+- Banque Kolb
+- Banque Laydernier
+- Banque Nuger
+- Banque Rhône-Alpes
+- Banque Tarneaud
+- Société Marseillaise de Crédit
+- Société de Banque Monaco
+
+Géré par la société Lyra-Network, se basant sur le code du module Systempay et Payzen

--- a/presta/systempay/inc/systempay.php
+++ b/presta/systempay/inc/systempay.php
@@ -36,7 +36,10 @@ function systempay_url_serveur($config){
 			break;		
 		case "sogecommerce":
 			$host = "https://sogecommerce.societegenerale.eu/vads-payment/";
-			break;			
+			break;	
+		case "scelliuspaiement":
+			$host = "https://scelliuspaiement.labanquepostale.fr/vads-payment/";
+			break;				
 		case "systempay":
 		case "cyberplus":
 		case "spplus":

--- a/presta/systempay/inc/systempay.php
+++ b/presta/systempay/inc/systempay.php
@@ -31,6 +31,9 @@ function systempay_url_serveur($config){
 		case "payzen":
 			$host = "https://secure.payzen.eu";
 			break;
+		case "clicandpay":
+			$host = "https://clicandpay.groupecdn.fr/vads-payment/";
+			break;			
 		case "systempay":
 		case "cyberplus":
 		case "spplus":

--- a/presta/systempay/inc/systempay.php
+++ b/presta/systempay/inc/systempay.php
@@ -33,6 +33,9 @@ function systempay_url_serveur($config){
 			break;
 		case "clicandpay":
 			$host = "https://clicandpay.groupecdn.fr/vads-payment/";
+			break;		
+		case "sogecommerce":
+			$host = "https://sogecommerce.societegenerale.eu/vads-payment/";
 			break;			
 		case "systempay":
 		case "cyberplus":


### PR DESCRIPTION
Clic&Pay est la solution de paiement pour les banques : 
- Crédit du Nord
- Banque Courtois
- Banque Kolb
- Banque Laydernier
- Banque Nuger
- Banque Rhône-Alpes
- Banque Tarneaud
- Société Marseillaise de Crédit
- Société de Banque Monaco

Basé sur les modules Sytempay et Payzen 
supporte les paiements par Carte Bancaire et Sepa SDD, en une fois ou par abonnements
