### PR TITLE
la fonction bank_config_id ne renvoie pas forcement un id unique

### DIFF
--- a/inc/bank.php
+++ b/inc/bank.php
@@ -205,7 +205,7 @@ function bank_config_id($config){
 		         'type',
 		         'cartes',
 		         'mode_test',
-		         'label',
+				 //'label',
 	         ) as $k){
 		if (isset($t[$k])){
 			unset($t[$k]);


### PR DESCRIPTION
la fonction bank_config_id doit permettre de différencier 2 config du même prestataire.

Hors, si on a 2 comptes "stripe", on se retrouve avec le meme identifiant : FDC7

Je propose d'ajouter le label dans le calcul de cet identifiant.

Sinon, on pourrait ajouter un champ : nom du compte