### PR TITLE
Support des devises (moins #54 en attente)

### DIFF
--- a/bank/inserer_transaction.php
+++ b/bank/inserer_transaction.php
@@ -71,10 +71,13 @@ function bank_inserer_transaction_dist($montant, $options = array()){
 	$montant = round($montant, 2);
 	$montant_ht = (isset($options['montant_ht']) ? $options['montant_ht'] : $montant);
 	$montant_ht = round($montant_ht, 2);
-
+	
+	$devise_defaut = bank_devise_defaut();
+	
 	$set = array(
 		'montant' => str_replace(',', '.', round($montant, 2)),
 		'montant_ht' => str_replace(',', '.', round($montant_ht, 2)),
+		'devise' => $devise_defaut['code'],
 		'id_auteur' => isset($options['id_auteur']) ? intval($options['id_auteur']) : 0,
 		'auteur_id' => isset($options['auteur_id']) ? $options['auteur_id'] : "",
 		'auteur' => isset($options['auteur']) ? $options['auteur'] : "",

--- a/bank_administrations.php
+++ b/bank_administrations.php
@@ -124,6 +124,11 @@ function bank_upgrade($nom_meta_base_version, $version_cible){
 	$maj['1.6.5'] = array(
 		array("sql_alter", "table spip_transactions CHANGE autorisation_id autorisation_id varchar(255) NOT NULL DEFAULT ''"),
 	);
+	
+	// Ajout du champ "devise"
+	$maj['1.7.0'] = array(
+		array('maj_tables', array('spip_transactions')),
+	);
 
 	include_spip('base/upgrade');
 	maj_plugin($nom_meta_base_version, $version_cible, $maj);

--- a/bank_options.php
+++ b/bank_options.php
@@ -88,6 +88,7 @@ function bank_affiche_payer($config, $type, $id_transaction, $transaction_hash, 
 		$devise_info = bank_devise_defaut();
 	}
 	
+	// On teste si ce prestataire sait gérer la devise demandée, sinon on ne l'affiche pas
 	if (!bank_tester_devise_presta($config['presta'], $devise_info['code'])) {
 		spip_log('La devise ' . $devise_info['code'] . 'n’est pas supportée pour presta=' . $config['presta'], 'bank' . _LOG_ERREUR);
 		return '';

--- a/bank_options.php
+++ b/bank_options.php
@@ -89,7 +89,7 @@ function bank_affiche_payer($config, $type, $id_transaction, $transaction_hash, 
 	}
 	
 	// On teste si ce prestataire sait gérer la devise demandée, sinon on ne l'affiche pas
-	if (!bank_tester_devise_presta($config['presta'], $devise_info['code'])) {
+	if (!bank_tester_devise_presta($config, $devise_info['code'])) {
 		spip_log('La devise ' . $devise_info['code'] . 'n’est pas supportée pour presta=' . $config['presta'], 'bank' . _LOG_ERREUR);
 		return '';
 	}
@@ -269,15 +269,15 @@ function bank_devise_defaut() {
 /**
  * Tester si une devise est supportée par un prestataire
  * 
- * @param $devise 
+ * @param array $config
+ * 		Tableau avec toutes les infos de config d'un prestataire
+ * @param string $devise 
  * 		Devise à tester en code ISO 4217 alphabétique
- * @param $presta
- * 		Type du prestataire à tester
  * @return bool
  * 		Renvoie true si la devise est ok, false sinon
  * 
  */
-function bank_tester_devise_presta($presta, $devise = null) {
+function bank_tester_devise_presta($config, $devise = null) {
 	$ok = false;
 	
 	// Si pas de devise, on prend celle générale par défaut
@@ -291,8 +291,8 @@ function bank_tester_devise_presta($presta, $devise = null) {
 
 	// Si le presta a une fonction qui définit les devises supportées, on l'utilise.
 	// Elle retourne soit un tableau, soit un booléen pour les accepter toutes.
-	if ($lister_devises = charger_fonction('lister_devises', 'presta/' . $presta, true)) {
-		$devises_ok = $lister_devises();
+	if ($lister_devises = charger_fonction('lister_devises', 'presta/' . $config['presta'], true)) {
+		$devises_ok = $lister_devises($config);
 	}
 
 	// Et enfin on teste

--- a/bank_options.php
+++ b/bank_options.php
@@ -225,7 +225,7 @@ function bank_lister_devises() {
  * Renvoie une ou toutes les infos sur une devise
  * 
  * @param string $code
- *    Code alphabétique à 3 lettres de la devise
+ *    Identifiant ISO 4217 alpha d'une devise
  */
 function bank_devise_info($code, $info='') {
 	$code = strtoupper($code);

--- a/bank_options.php
+++ b/bank_options.php
@@ -187,6 +187,63 @@ function bank_annonce_version_plugin($format = 'string'){
 }
 
 /**
+ * 	Renvoie la liste des devises possibles, et toutes leurs infos nécessaires
+ * 
+ * @pipeline_appel bank_lister_devises
+ * @return array
+ * 		Tableau de toutes les devises avec pour chacune leurs infos complètes au format
+ * 		```
+ * 		array(
+ * 			'EUR' => array(
+ * 				'code' => 'EUR',
+ * 				'code_num' => 978,
+ * 				'nom' => 'euro',
+ * 				'fraction' => 2,
+ * 				'symbole' => '€',
+ * 				'locale' => 'fr_FR',
+ * 			)
+ * 		)
+ * 		```
+ */
+function bank_lister_devises() {
+	$devises = array(
+		'EUR' => array(
+			'code' => 'EUR',
+			'code_num' => 978,
+			'nom' => 'euro',
+			'fraction' => 2,
+			'symbole' => '€',
+		),
+	);
+	
+	$devises = pipeline('bank_lister_devises', $devises);
+	
+	return $devises;
+}
+
+/**
+ * Renvoie une ou toutes les infos sur une devise
+ * 
+ * @param string $code
+ *    Code alphabétique à 3 lettres de la devise
+ */
+function bank_devise_info($code, $info='') {
+	$code = strtoupper($code);
+	$devises = bank_lister_devises();
+	$retour = null;
+	
+	if (isset($devises[$code])) {
+		$retour = $devises[$code];
+		
+		if ($info) {
+			$retour = (isset($retour[$info]) ? $retour[$info] : null);
+		}
+	}
+	
+	return $retour;
+}
+
+/**
  * Renvoie la devise par défaut utilisée par Bank, modifiable par pipeline
  * 
  * @pipeline_appel bank_devise_defaut
@@ -194,15 +251,11 @@ function bank_annonce_version_plugin($format = 'string'){
  *     Identifiant ISO 4217 alpha d'une devise
  */
 function bank_devise_defaut() {
-	$devise = array(
-		'code' => 'EUR',
-		'code_num' => 978,
-		'fraction' => 2,
-	);
+	$devise_defaut = bank_devise_info('EUR');
 	
-	$devise = pipeline('bank_devise_defaut', $devise);
+	$devise_defaut = pipeline('bank_devise_defaut', $devise_defaut);
 	
-	return $devise;
+	return $devise_defaut;
 }
 
 /**

--- a/bank_options.php
+++ b/bank_options.php
@@ -79,10 +79,17 @@ function bank_affiche_payer($config, $type, $id_transaction, $transaction_hash, 
 
 	$quoi = ($type=='abo' ? 'abonnement' : 'acte');
 	
-	$devise_defaut = bank_devise_defaut();
+	// On va chercher la devise de la transaction
+	if ($devise = sql_getfetsel('devise', 'spip_transactions', 'id_transaction = '.intval($id_transaction))) {
+		$devise_info = bank_devise_info($devise);
+	}
+	// Sinon celle par défaut
+	else {
+		$devise_info = bank_devise_defaut();
+	}
 	
-	if (!bank_tester_devise_presta($config['presta'], $devise_defaut['code'])) {
-		spip_log('La devise ' . $devise_defaut['code'] . 'n’est pas supportée pour presta=' . $config['presta'], 'bank' . _LOG_ERREUR);
+	if (!bank_tester_devise_presta($config['presta'], $devise_info['code'])) {
+		spip_log('La devise ' . $devise_info['code'] . 'n’est pas supportée pour presta=' . $config['presta'], 'bank' . _LOG_ERREUR);
 		return '';
 	}
 	

--- a/base/bank.php
+++ b/base/bank.php
@@ -42,6 +42,7 @@ function bank_declarer_tables_objets_sql($tables){
 			"contenu" => "TEXT NOT NULL DEFAULT ''", // contenu sous forme texte serializee, a toute fin utile
 			"montant_ht" => "varchar(25) NOT NULL DEFAULT ''", // montant ht en euros
 			"montant" => "varchar(25) NOT NULL DEFAULT ''", // montant ttc en euros
+			"devise" => "varchar(25) NOT NULL DEFAULT 'EUR'", // code alpha d'une devise, normalement en majuscule
 
 			"mode" => "varchar(25) NOT NULL DEFAULT ''", // mode de paiement (prestataire)
 			"autorisation_id" => "varchar(255) NOT NULL DEFAULT ''", // numero d'autorisation de debit envoye par le presta bancaire

--- a/lang/bank_fr.php
+++ b/lang/bank_fr.php
@@ -157,6 +157,7 @@ _ Compte bancaire :
 	'label_resilier_abonnement' => 'Résilier',
 	'label_tri_mode' => 'Mode',
 	'label_tri_autorisation' => 'Autorisation',
+	'label_tri_devise' => 'Devise',
 	'label_tri_montant_ht' => 'HT',
 	'label_tri_montant_ttc' => 'TTC',
 	'label_tri_montant_paye' => 'Réglé',

--- a/lang/bank_fr.php
+++ b/lang/bank_fr.php
@@ -105,6 +105,7 @@ _ Compte bancaire :
 	'label_configuration_autres_moyens' => 'Proposer aussi :',
 	'label_configuration_cartes' => 'Proposer les cartes de paiement :',
 	'label_configuration_cheque_adresse' => 'Adresse où envoyer les chèques',
+	'label_configuration_cheque_devise' => 'Devise',
 	'label_configuration_cheque_notice' => 'Information complémentaire affichée',
 	'label_configuration_cheque_ordre' => 'Ordre',
 	'label_configuration_type' => 'Type de paiements',

--- a/paquet.xml
+++ b/paquet.xml
@@ -22,6 +22,7 @@
 	<pipeline nom="affiche_auteurs_interventions" inclure="bank_fonctions.php" />
 	<pipeline nom="taches_generales_cron" inclure="bank_fonctions.php" />
 
+	<pipeline nom="bank_lister_devises" action="" />
 	<pipeline nom="bank_devise_defaut" action="" />
 	<pipeline nom="bank_dsp2_renseigner_facturation" action="" />
 	<pipeline nom="bank_abos_activer_abonnement" action="" />

--- a/paquet.xml
+++ b/paquet.xml
@@ -6,7 +6,7 @@
 	compatibilite="[3.1.0;3.3.*]"
 	logo="prive/themes/spip/images/bank-32.png"
 	documentation="http://contrib.spip.net/4627"
-	schema="1.6.5"
+	schema="1.7.0"
 >
 
 	<nom>Banque&amp;paiement</nom>

--- a/presta/cheque/inc-configurer.html
+++ b/presta/cheque/inc-configurer.html
@@ -1,4 +1,14 @@
 <ul class="editer-groupe">
+	#SET{devises, #REM|bank_lister_devises}
+	#SET{name, #ENV{casier,''}_devise}#SET{obli,oui}#SET{defaut,#REM|bank_devise_defaut|table_valeur{code}}#SET{erreurs,#ENV**{erreurs}|table_valeur{#GET{name}}}
+	<li class="editer editer_[(#GET{name})][ (#GET{obli})][ (#GET{erreurs}|oui)erreur]">
+		<label for="#GET{name}"><:bank:label_configuration_cheque_devise:></label>
+		<select name="#ENV{casier,''}[devise]" id="#GET{name}">
+			<BOUCLE_devises(DATA){source table, #GET{devises}}{par nom}>
+			<option value="#VALEUR{code}" [(#ENV*{#ENV{casier, ''}}|table_valeur{devise,#GET{defaut}}|=={#VALEUR{code}}|oui)selected="selected"]>[(#VALEUR{nom})] (#VALEUR{code})</option>
+			</BOUCLE_devises>
+		</select>
+	</li>
 	#SET{name,#ENV{casier,''}_ordre}#SET{obli,''}#SET{defaut,''}#SET{erreurs,#ENV**{erreurs}|table_valeur{#GET{name}}}
 	<li class="editer editer_[(#GET{name})][ (#GET{obli})][ (#GET{erreurs}|oui)erreur]">
 		<label for="#GET{name}"><:bank:label_configuration_cheque_ordre:></label>[

--- a/presta/cheque/lister_devises.php
+++ b/presta/cheque/lister_devises.php
@@ -4,6 +4,11 @@ if (!defined('_ECRIRE_INC_VERSION')) {
 	return;
 }
 
-function presta_cheque_lister_devises_dist() {
+function presta_cheque_lister_devises_dist($config) {
+	// Si ce mode par chèque a une config de devise, c'est uniquement ça qui est accepté
+	if ($config['devise']) {
+		return array($config['devise']);
+	}
+	
 	return true;
 }

--- a/presta/cmcic/call/request.php
+++ b/presta/cmcic/call/request.php
@@ -68,7 +68,11 @@ function presta_cmcic_call_request_dist($id_transaction, $transaction_hash, $con
 	if (!$row = sql_fetsel("*", "spip_transactions", "id_transaction=" . intval($id_transaction) . " AND transaction_hash=" . sql_quote($transaction_hash))){
 		return array();
 	}
-
+	
+	// On peut maintenant connaître la devise et ses infos
+	$devise = $row['devise'];
+	$devise_info = bank_devise_info($devise);
+	
 	include_spip('inc/filtres');
 	$contexte = array();
 
@@ -88,8 +92,7 @@ function presta_cmcic_call_request_dist($id_transaction, $transaction_hash, $con
 
 
 	// Currency : ISO 4217 compliant
-	$devise_defaut = bank_devise_defaut();
-	$devise = strtoupper($devise_defaut['code']);
+	$devise = strtoupper($devise_info['code']);
 	// Amount : format  "xxxxx.yy" (no spaces)
 	$montant = $row['montant'];
 	$contexte['version'] = $oTpe->sVersion;

--- a/presta/ogone/call/request.php
+++ b/presta/ogone/call/request.php
@@ -67,7 +67,11 @@ function presta_ogone_call_request_dist($id_transaction, $transaction_hash, $con
 	if (!$row = sql_fetsel("*", "spip_transactions", "id_transaction=" . intval($id_transaction) . " AND transaction_hash=" . sql_quote($transaction_hash))){
 		return array();
 	}
-
+	
+	// On peut maintenant connaître la devise et ses infos
+	$devise = $row['devise'];
+	$devise_info = bank_devise_info($devise);
+	
 	if (!$row['id_auteur']
 		AND isset($GLOBALS['visiteur_session']['id_auteur'])
 		AND $GLOBALS['visiteur_session']['id_auteur']){
@@ -90,9 +94,8 @@ function presta_ogone_call_request_dist($id_transaction, $transaction_hash, $con
 	$contexte['operation'] = "SAL"; // c'est un paiement a l'acte immediat
 
 	// passage en centimes d'euros : round en raison des approximations de calcul de PHP
-	$devise_defaut = bank_devise_defaut();
-	$contexte['currency'] = $devise_defaut['code'];
-	$contexte['amount'] = intval(round((10**$devise_defaut['fraction']) * $row['montant'], 0));
+	$contexte['currency'] = $devise_info['code'];
+	$contexte['amount'] = intval(round((10**$devise_info['fraction']) * $row['montant'], 0));
 
 	#if (strlen($montant)<3)
 	#	$montant = str_pad($montant,3,'0',STR_PAD_LEFT);

--- a/presta/ogone/call/request.php
+++ b/presta/ogone/call/request.php
@@ -95,7 +95,7 @@ function presta_ogone_call_request_dist($id_transaction, $transaction_hash, $con
 
 	// passage en centimes d'euros : round en raison des approximations de calcul de PHP
 	$contexte['currency'] = $devise_info['code'];
-	$contexte['amount'] = intval(round((10**$devise_info['fraction']) * $row['montant'], 0));
+	$contexte['amount'] = intval(round(100 * $row['montant'], 0));
 
 	#if (strlen($montant)<3)
 	#	$montant = str_pad($montant,3,'0',STR_PAD_LEFT);

--- a/presta/paybox/inc/paybox.php
+++ b/presta/paybox/inc/paybox.php
@@ -357,7 +357,11 @@ function paybox_traite_reponse_transaction($config, $response){
 			)
 		);
 	}
-
+	
+	// On peut maintenant connaître la devise et ses infos
+	$devise = $row['devise'];
+	$devise_info = bank_devise_info($devise);
+	
 	// ok, on traite le reglement
 	$date = $_SERVER['REQUEST_TIME'];
 	$date_paiement = sql_format_date(
@@ -398,8 +402,7 @@ function paybox_traite_reponse_transaction($config, $response){
 	// Ouf, le reglement a ete accepte
 
 	// on verifie que le montant est bon !
-	$devise_defaut = bank_devise_defaut();
-	$montant_regle = $response['montant'] / (10**$devise_defaut['fraction']);
+	$montant_regle = $response['montant'] / (10**$devise_info['fraction']);
 	if ($montant_regle!=$row['montant']){
 		spip_log($t = "call_response : id_transaction $id_transaction, montant regle $montant_regle!=" . $row['montant'] . ":" . paybox_shell_args($response), $mode);
 		// on log ca dans un journal dedie

--- a/presta/paypal/inc/paypal.php
+++ b/presta/paypal/inc/paypal.php
@@ -103,7 +103,11 @@ function paypal_traite_response($config, $response){
 			)
 		);
 	}
-
+	
+	// On peut maintenant connaître la devise et ses infos
+	$devise = $row['devise'];
+	$devise_info = bank_devise_info($devise);
+	
 	if ($row['reglee']=='oui'){
 		return array($id_transaction, true);
 	} // cette transaction a deja ete reglee. double entree, on ne fait rien
@@ -155,8 +159,7 @@ function paypal_traite_response($config, $response){
 	sql_updateq("spip_transactions", $set, "id_transaction=" . intval($id_transaction));
 
 	// une monnaie est-elle bien indique (et en EUR) ?
-	$devise_defaut = bank_devise_defaut();
-	if (!isset($response['mc_currency']) OR ($response['mc_currency'] != strtoupper($devise_defaut['code']))) {
+	if (!isset($response['mc_currency']) OR ($response['mc_currency'] != strtoupper($devise_info['code']))) {
 		return bank_transaction_echec($id_transaction,
 			array(
 				'mode' => $mode,

--- a/presta/paypal/payer/acte.html
+++ b/presta/paypal/payer/acte.html
@@ -25,7 +25,7 @@
 				<input type="hidden" name="amount" value="#MONTANT" />
 				<input type="hidden" name="no_note" value="1" />
 				<input type="hidden" name="business" value="#ENV{config/BUSINESS_USERNAME}" />
-				<input type="hidden" name="currency_code" value="[(#VAL|bank_devise_defaut|table_valeur{code}|strtoupper)]" />
+				<input type="hidden" name="currency_code" value="[(#DEVISE|strtoupper)]" />
 				<input type="hidden" name="lc" value="FR" />
 				<input type="hidden" name="invoice" value="#ID_TRANSACTION-#TRANSACTION_HASH" />
 				<BOUCLE_profil(AUTEURS){id_auteur}>

--- a/presta/paypalexpress/inc/paypalexpress.php
+++ b/presta/paypalexpress/inc/paypalexpress.php
@@ -104,7 +104,11 @@ function bank_paypalexpress_order_init($config, $id_transaction, $url_confirm = 
 		);
 		return false;
 	}
-
+	
+	// On peut maintenant connaître la devise et ses infos
+	$devise = $row['devise'];
+	$devise_info = bank_devise_info($devise);
+	
 	if ($row['reglee']=='oui'){
 		bank_transaction_invalide($id_transaction,
 			array(
@@ -127,8 +131,7 @@ function bank_paypalexpress_order_init($config, $id_transaction, $url_confirm = 
 	portion of the URL that buyers will return to after authorizing payment
 	*/
 	$paymentAmount = $row['montant'];
-	$devise_defaut = bank_devise_defaut();
-	$currencyCodeType = strtoupper($devise_defaut['code']);
+	$currencyCodeType = strtoupper($devise_info['code']);
 	$paymentType = "Sale";
 
 
@@ -213,7 +216,11 @@ function bank_paypalexpress_checkoutpayment($payerid, $config){
 			)
 		);
 	}
-
+	
+	// On peut maintenant connaître la devise et ses infos
+	$devise = $row['devise'];
+	$devise_info = bank_devise_info($devise);
+	
 	// hmm bizare, double hit ? On fait comme si c'etait OK
 	if ($row['reglee']=='oui'){
 		spip_log("Erreur transaction $id_transaction deja reglee", $mode . _LOG_INFO_IMPORTANTE);
@@ -242,8 +249,7 @@ function bank_paypalexpress_checkoutpayment($payerid, $config){
 	*/
 	$token = urlencode($_SESSION['token']);
 	$paymentAmount = $row['montant'];
-	$devise_defaut = bank_devise_defaut();
-	$currencyCodeType = strtoupper($devise_defaut['code']);
+	$currencyCodeType = strtoupper($devise_info['code']);
 	$paymentType = "Sale";
 	$payerID = urlencode($_SESSION['payer_id']);
 	$serverName = urlencode($_SERVER['SERVER_NAME']);

--- a/presta/sips/inc/sips.php
+++ b/presta/sips/inc/sips.php
@@ -253,7 +253,11 @@ function sips_traite_reponse_transaction($config, $response){
 			)
 		);
 	}
-
+	
+	// On peut maintenant connaître la devise et ses infos
+	$devise = $row['devise'];
+	$devise_info = bank_devise_info($devise);
+	
 	/*
 	include_spip('inc/filtres');
 	if ($transaction_hash!=modulo($row['transaction_hash'],999999)){
@@ -309,8 +313,7 @@ function sips_traite_reponse_transaction($config, $response){
 	// Ouf, le reglement a ete accepte
 
 	// on verifie que le montant est bon !
-	$devise_defaut = bank_devise_defaut();
-	$montant_regle = $response[($mode=='sipsabo' ? 'sub_' : '') . 'amount'] / (10**$devise_defaut['fraction']);
+	$montant_regle = $response[($mode=='sipsabo' ? 'sub_' : '') . 'amount'] / (10**$devise_info['fraction']);
 	if ($montant_regle!=$row['montant']){
 		spip_log($t = "call_response : id_transaction $id_transaction, montant regle $montant_regle!=" . $row['montant'] . ":" . sips_shell_args($response), $mode);
 		// on log ca dans un journal dedie

--- a/presta/sipsv2/inc/sipsv2.php
+++ b/presta/sipsv2/inc/sipsv2.php
@@ -266,7 +266,11 @@ function sipsv2_traite_reponse_transaction($config, $response){
 			)
 		);
 	}
-
+	
+	// On peut maintenant connaître la devise et ses infos
+	$devise = $row['devise'];
+	$devise_info = bank_devise_info($devise);
+	
 	// ok, on traite le reglement
 	//"Y-m-d H:i:s"
 	$date_paiement = date('Y-m-d H:i:s', strtotime($response['transactionDateTime']));
@@ -298,8 +302,7 @@ function sipsv2_traite_reponse_transaction($config, $response){
 	// Ouf, le reglement a ete accepte
 
 	// on verifie que le montant est bon !
-	$devise_defaut = bank_devise_defaut();
-	$montant_regle = round($response['amount'] / (10**$devise_defaut['fraction']), 2);
+	$montant_regle = round($response['amount'] / (10**$devise_info['fraction']), 2);
 	if ($montant_regle!=$row['montant']){
 		spip_log($t = "call_response : id_transaction $id_transaction, montant regle $montant_regle!=" . $row['montant'] . ":" . bank_shell_args($response), $logname . _LOG_ERREUR);
 		// on log ca dans un journal dedie

--- a/presta/stripe/call/request.php
+++ b/presta/stripe/call/request.php
@@ -30,7 +30,6 @@ include_spip('presta/stripe/inc/stripe');
  * @return array
  */
 function presta_stripe_call_request_dist($id_transaction, $transaction_hash, $config, $type = "acte"){
-	$devise_defaut = bank_devise_defaut();
 	$mode = 'stripe';
 	if (!is_array($config) OR !isset($config['type']) OR !isset($config['presta'])){
 		spip_log("call_request : config invalide " . var_export($config, true), $mode . _LOG_ERREUR);
@@ -45,7 +44,11 @@ function presta_stripe_call_request_dist($id_transaction, $transaction_hash, $co
 		spip_log("call_request : transaction $id_transaction / $transaction_hash introuvable", $mode . _LOG_ERREUR);
 		return "";
 	}
-
+	
+	// On peut maintenant connaître la devise et ses infos
+	$devise = $row['devise'];
+	$devise_info = bank_devise_info($devise);
+	
 	if (!$row['id_auteur']
 		AND isset($GLOBALS['visiteur_session']['id_auteur'])
 		AND $GLOBALS['visiteur_session']['id_auteur']){
@@ -96,7 +99,7 @@ function presta_stripe_call_request_dist($id_transaction, $transaction_hash, $co
 	$email = $billing['email'];
 
 	// passage en centimes d'euros : round en raison des approximations de calcul de PHP
-	$montant = intval(round((10**$devise_defaut['fraction']) * $row['montant'], 0));
+	$montant = intval(round((10**$devise_info['fraction']) * $row['montant'], 0));
 	if (strlen($montant)<3){
 		$montant = str_pad($montant, 3, '0', STR_PAD_LEFT);
 	}
@@ -122,7 +125,7 @@ function presta_stripe_call_request_dist($id_transaction, $transaction_hash, $co
 	$contexte['action'] = str_replace('&', '&amp;', $url_success);
 	$contexte['email'] = $email;
 	$contexte['amount'] = $montant;
-	$contexte['currency'] = strtolower($devise_defaut['code']);
+	$contexte['currency'] = strtolower($devise_info['code']);
 	$contexte['key'] = ($config['mode_test'] ? $config['PUBLISHABLE_KEY_test'] : $config['PUBLISHABLE_KEY']);
 	$contexte['name'] = bank_nom_site();
 	$contexte['description'] = _T('bank:titre_transaction') . '#' . $id_transaction;
@@ -202,7 +205,7 @@ function presta_stripe_call_request_dist($id_transaction, $transaction_hash, $co
 	if ($type === 'abo' and $echeance){
 		if ($echeance['montant'] > 0) {
 
-			$montant_echeance = intval(round((10**$devise_defaut['fraction']) * $echeance['montant'], 0));
+			$montant_echeance = intval(round((10**$devise_info['fraction']) * $echeance['montant'], 0));
 			if (strlen($montant_echeance) < 3) {
 				$montant_echeance = str_pad($montant_echeance, 3, '0', STR_PAD_LEFT);
 			}

--- a/presta/stripe/inc/stripe.php
+++ b/presta/stripe/inc/stripe.php
@@ -190,7 +190,11 @@ function stripe_traite_reponse_transaction($config, &$response){
 			)
 		);
 	}
-
+	
+	// On peut maintenant connaître la devise et ses infos
+	$devise = $row['devise'];
+	$devise_info = bank_devise_info($devise);
+	
 	// ok, on traite le reglement
 	$date = $_SERVER['REQUEST_TIME'];
 	$date_paiement = date('Y-m-d H:i:s', $date);
@@ -270,8 +274,7 @@ function stripe_traite_reponse_transaction($config, &$response){
 	// Ouf, le reglement a ete accepte
 
 	// on verifie que le montant est bon !
-	$devise_defaut = bank_devise_defaut();
-	$montant_regle = $payment->amount_received / (10**$devise_defaut['fraction']);
+	$montant_regle = $payment->amount_received / (10**$devise_info['fraction']);
 
 	if ($montant_regle!=$row['montant']){
 		spip_log($t = "call_response : id_transaction $id_transaction, montant regle $montant_regle!=" . $row['montant'] . ":" . var_export($payment, true), $mode);

--- a/presta/systempay/call/request.php
+++ b/presta/systempay/call/request.php
@@ -74,7 +74,11 @@ function presta_systempay_call_request_dist($id_transaction, $transaction_hash, 
 	if (!$row = sql_fetsel("*", "spip_transactions", "id_transaction=" . intval($id_transaction) . " AND transaction_hash=" . sql_quote($transaction_hash))){
 		return array();
 	}
-
+	
+	// On peut maintenant connaître la devise et ses infos
+	$devise = $row['devise'];
+	$devise_info = bank_devise_info($devise);
+	
 	if (!$row['id_auteur']
 		AND isset($GLOBALS['visiteur_session']['id_auteur'])
 		AND $GLOBALS['visiteur_session']['id_auteur']){
@@ -110,9 +114,8 @@ function presta_systempay_call_request_dist($id_transaction, $transaction_hash, 
 	//$parm['vads_validation_mode'] = 0;
 
 	// passage en centimes d'euros : round en raison des approximations de calcul de PHP
-	$devise_defaut = bank_devise_defaut();
-	$parm['vads_currency'] = $devise_defaut['code_num'];
-	$parm['vads_amount'] = intval(round((10**$devise_defaut['fraction']) * $row['montant'], 0));
+	$parm['vads_currency'] = $devise_info['code_num'];
+	$parm['vads_amount'] = intval(round((10**$devise_info['fraction']) * $row['montant'], 0));
 
 	$parm['vads_language'] = $GLOBALS['spip_lang'];
 
@@ -200,7 +203,7 @@ function presta_systempay_call_request_dist($id_transaction, $transaction_hash, 
 				}
 
 				// montant de l'echeance
-				$parm['vads_sub_amount'] = intval(round((10**$devise_defaut['fraction']) * $echeance['montant'], 0));
+				$parm['vads_sub_amount'] = intval(round((10**$devise_info['fraction']) * $echeance['montant'], 0));
 				// meme devise que le paiement initial
 				$parm['vads_sub_currency'] = $parm['vads_currency'];
 
@@ -235,7 +238,7 @@ function presta_systempay_call_request_dist($id_transaction, $transaction_hash, 
 				if ($nb_init>0){
 					$parm['vads_sub_init_amount_number'] = $nb_init;
 					$parm['vads_sub_init_amount'] = $parm['vads_amount'];
-					if (isset($echeance['montant_init']) AND ($m = intval(round((10**$devise_defaut['fraction']) * $echeance['montant_init'], 0)))>0){
+					if (isset($echeance['montant_init']) AND ($m = intval(round((10**$devise_info['fraction']) * $echeance['montant_init'], 0)))>0){
 						$parm['vads_sub_init_amount'] = $m;
 					}
 				}

--- a/presta/systempay/inc/systempay.php
+++ b/presta/systempay/inc/systempay.php
@@ -378,8 +378,9 @@ function systempay_traite_reponse_transaction($config, $response){
 	if ($is_payment){
 		// Ouf, le reglement a ete accepte
 		// on verifie que le montant est bon !
-		$devise_defaut = bank_devise_defaut();
-		$montant_regle = $response['vads_effective_amount'] / (10**$devise_defaut['fraction']);
+		$devise = $row['devise'];
+		$devise_info = bank_devise_info($devise);
+		$montant_regle = $response['vads_effective_amount'] / (10**$devise_info['fraction']);
 		if ($montant_regle!=$row['montant']){
 			spip_log($t = "call_response : id_transaction $id_transaction, montant regle $montant_regle!=" . $row['montant'] . ":" . bank_shell_args($response), $mode);
 			// on log ca dans un journal dedie

--- a/prive/objets/liste/transactions.html
+++ b/prive/objets/liste/transactions.html
@@ -18,6 +18,7 @@
 				<th class='autorisation_id' scope='col'>[(#TRI{autorisation_id,<:bank:label_tri_autorisation:>,ajax})]</th>
 				<th class='montant_ht' scope='col'>[(#TRI{montant_ht,<:bank:label_tri_montant_ht:>,ajax})]</th>
 				<th class='montant' scope='col'>[(#TRI{montant,<:bank:label_tri_montant_ttc:>,ajax})]</th>
+				<th class='devise' scope='col'>[(#TRI{devise,<:bank:label_tri_devise:>,ajax})]</th>
 				<th class='regle' scope='col'>[(#TRI{montant_regle,<:bank:label_tri_montant_paye:>,ajax})]</th>
 				<th class='date' scope='col'>[(#TRI{date_transaction,<:date:>,ajax})]</th>
 				<th class='statut' scope='col'>[(#TRI{statut,<:bank:label_tri_statut:>,ajax})]</th>
@@ -44,6 +45,7 @@
 				<td class="autorisation_id"><abbr title="#AUTORISATION_ID">[(#AUTORISATION_ID|couper{15})]</abbr></td>
 				<td class="montant_ht">#MONTANT_HT</td>
 				<td class="montant">#MONTANT</td>
+				<td class="devise">#DEVISE</td>
 				<td class="regle">#MONTANT_REGLE</td>
 				<td class="date">#DATE_TRANSACTION</td>
 				<td class="statut">[(#STATUT|match{echec|ok|rembourse}|et{#MESSAGE|trim|strlen}|?{[<abbr title="[(#MESSAGE|attribut_html)[ - (#ERREUR|attribut_html)]]">(#STATUT)</abbr>],#STATUT})][(#STATUT|in_array{#LISTE{commande,attente}}|et{#AUTORISER{regler,transaction,#ID_TRANSACTION}})<br/><a href="[(#URL_ECRIRE{payer,id_transaction=#ID_TRANSACTION}|parametre_url{transaction_hash,#TRANSACTION_HASH})]"><:bank:payer:></a>]</td>


### PR DESCRIPTION
Cette PR intègre le support des devises suivant les tickets https://github.com/nursit/bank/milestone/1 mais seulement les tickets #53 et #55 . Pour le #54 c'est de l'amélioration/mutualisation mais pas obligatoire puisqu'il n'y a pas de mutualisation actuellement, c'est déjà dans le code propre à chaque presta donc bien déjà personnalisable même si à chaque endroit précis (et possiblement il faudrait pas, questionnement en cours). En tout cas c'est utilisable sans le 54 donc ça peut venir plus tard, en intégrant déjà ça.

Par ailleurs, le plugin Intl https://git.spip.net/spip-contrib-extensions/intl/ qui sépare la lib qui était pour l'instant dans Prix, utilise le pipeline pour fournir la liste complète.