### PR TITLE
utiliser bank_porteur_infos_facturation() pour récupérer l'email

### DIFF
--- a/presta/paybox/call/request.php
+++ b/presta/paybox/call/request.php
@@ -65,7 +65,8 @@ function presta_paybox_call_request_dist($id_transaction, $transaction_hash, $co
 		);
 	}
 
-	$mail = bank_porteur_email($row);
+	$billing = bank_porteur_infos_facturation($row);
+	$mail = $billing['email'];
 
 	// passage en centimes d'euros : round en raison des approximations de calcul de PHP
 	$montant = intval(round((10**$devise_info['fraction']) * $row['montant'], 0));


### PR DESCRIPTION
comme pour d'autres prestataires, utiliser la fonction `bank_porteur_infos_facturation()` pour récupérer l'email afin de pouvoir utiliser le pipeline `bank_dsp2_renseigner_facturation` pour gérer le mail envoyé