### PR TITLE
[css] bouton payer n'était plus lisible en SPIP4

### DIFF
--- a/prive/squelettes/contenu/payer.html
+++ b/prive/squelettes/contenu/payer.html
@@ -40,10 +40,10 @@
 	.payer_mode .boutons .submit .logo {display: inline-block;}
 	.payer_mode .boutons .submit img {max-width: 58px;height: auto}
 	.payer_mode .boutons .submit .logo+.texte {display: none;}
-	.payer_mode .boutons .submit { padding:5px 15px; border:1px solid #ccc; background: #eee; }
+	.payer_mode .boutons .submit { padding:5px 15px; border:1px solid #ccc;}
 	.payer_mode .boutons .submit:hover { cursor: pointer; background: #ddd; }
 	.payer_mode .explication+.boutons {float: right;margin-top:-3em;}
-	.payer_mode .explication+.boutons:after {display:block;height:1px;line-height1px;clear:both;}
+	.payer_mode .explication+.boutons:after {display:block;height:1px;line-height:1px;clear:both;}
 	.bouton_action_post.right {float: right;}
 
 	</style>


### PR DESCRIPTION

En SPIP 4 le bouton payer n'est plus très lisible 

![BUG_before](https://user-images.githubusercontent.com/4166085/142625346-9f36a026-8cef-49de-8696-a6186db8ab84.png)

Si on corrige cela donne

![BUG_after](https://user-images.githubusercontent.com/4166085/142625342-15f8a3a2-7fff-4564-8a08-3e5b73af4630.png)
