### PR TITLE
fix: ne pas ouvrir de checkout_session chez Stripe avant appuis sur le bouton de paiement par Stripe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Plugin Bank v5-dev pour SPIP <small>Paiement bancaire</small>
+# Plugin Bank v5 pour SPIP <small>Paiement bancaire</small>
 
 Ce plugin permet de gérer les interfaces techniques avec les prestataires bancaires.
 
@@ -17,6 +17,9 @@ Il peut aussi être complété par
 
 
 ### Changelog
+
+* Version 5.1
+  * Compatibilité SPIP 4.1
 
 * Version 5.0
   * Support des devises
@@ -37,10 +40,10 @@ Il peut aussi être complété par
     * seul le paiement à l'acte est implémenté, les nouveaux paiements récurrents ne sont plus possibles (TODO)
   * Suppression du prestataire Internet+ (code non maintenu, non testé en situation réelle depuis trop longtemps)
   * Passage a la plateforme Monetico au lieu de CMCIC (rien a reconfigurer, c'est un switch transparent)
-  
+
 * Version 3 du plugin
   * Nécessite SPIP 3.0+, compatible SPIP 3.1 et SPIP 3.2
-  * Refonte de la configuration : 
+  * Refonte de la configuration :
     * on peut avoir plusieurs modules du même prestataire technique avec des paramètres différents
     * possibilité de configurer l'ordre de présentation des modes de paiement
     * possibilité de configurer les CB proposées pour les prestataires par CB qui le permettent (tous sauf SIPS)
@@ -89,7 +92,6 @@ Le plugin permet aussi les paiements mensuels avec les plateformes techniques su
 * PayZen
 * Stripe
 
-Un mode de paiement "Simulation" permet de tester le workflow de paiement pendant la phase de developpement. 
+Un mode de paiement "Simulation" permet de tester le workflow de paiement pendant la phase de developpement.
 
 Les documentations (pdf) des différentes plateformes sont centralisées à cette adresse : http://www.nursit.com/doc_presta_bank .
-

--- a/presta/stripe/call/request.php
+++ b/presta/stripe/call/request.php
@@ -29,7 +29,7 @@ include_spip('presta/stripe/inc/stripe');
  *   type de paiement : acte ou abo
  * @return array|false
  */
-function presta_stripe_call_request_dist($id_transaction, $transaction_hash, $config, $type = "acte"){
+function presta_stripe_call_request_dist($id_transaction, $transaction_hash, $config, $type = "acte", $options = []){
 	$mode = 'stripe';
 	if (!is_array($config) OR !isset($config['type']) OR !isset($config['presta'])){
 		spip_log("call_request : config invalide " . var_export($config, true), $mode . _LOG_ERREUR);
@@ -165,149 +165,48 @@ function presta_stripe_call_request_dist($id_transaction, $transaction_hash, $co
 		$item['images'] = [$contexte['image']];
 	}
 
-	stripe_init_api($config);
-	stripe_set_webhook($config);
+	if (!isset($options['process_checkout']) or $options['process_checkout']) {
 
-	$checkout_customer = null;
-	// essayer de retrouver un customer existant pour l'id_auteur
-	// sinon Stripe creera un nouveau customer
-	if ($row['id_auteur']){
-		$config_id = bank_config_id($config);
-		$customer_id = sql_getfetsel('pay_id', 'spip_transactions',
-			'pay_id!=' . sql_quote('') . ' AND id_auteur=' . intval($row['id_auteur']) . ' AND statut=' . sql_quote('ok') . ' AND mode=' . sql_quote("$mode/$config_id"),
-			'', 'date_paiement DESC', '0,1');
-		if ($customer_id){
-			try {
-				$customer = \Stripe\Customer::retrieve($customer_id);
-				if ($customer and $customer->email===$contexte['email']){
-					$checkout_customer = $customer_id;
+		stripe_init_api($config);
+		stripe_set_webhook($config);
+
+		$checkout_customer = null;
+		// essayer de retrouver un customer existant pour l'id_auteur
+		// sinon Stripe creera un nouveau customer
+		if ($row['id_auteur']){
+			$config_id = bank_config_id($config);
+			$customer_id = sql_getfetsel('pay_id', 'spip_transactions',
+				'pay_id!=' . sql_quote('') . ' AND id_auteur=' . intval($row['id_auteur']) . ' AND statut=' . sql_quote('ok') . ' AND mode=' . sql_quote("$mode/$config_id"),
+				'', 'date_paiement DESC', '0,1');
+			if ($customer_id){
+				try {
+					$customer = \Stripe\Customer::retrieve($customer_id);
+					if ($customer and $customer->email===$contexte['email']){
+						$checkout_customer = $customer_id;
+					}
+				} catch (Exception $e) {
+					// On ignore silencieusement cette erreur
 				}
-			} catch (Exception $e) {
-				// On ignore silencieusement cette erreur
 			}
 		}
-	}
-	if (!$checkout_customer){
-		// TODO : creer un customer avec les billing infos
-	}
-
-	// mettre le customer id en base dans la transaction pour aider a la retrouver en cas d'echec
-	if ($checkout_customer and empty($row['pay_id'])) {
-		$row['pay_id'] = $customer->id;
-		sql_updateq("spip_transactions", ['pay_id' => $row['pay_id']], 'id_transaction='.intval($id_transaction));
-	}
-
-
-	$payment_types = array_intersect($cartes, array_keys($cartes_possibles));
-	if (!$payment_types) {
-		$payment_types = ['card'];
-	}
-
-	// acte : utiliser une checkout session
-	if ($type==='acte'){
-		$product_data = [
-			'name' => $item['name'],
-			'description' => $item['description'],
-			'metadata' => $item['metadata'],
-		];
-		if (empty($product_data['description'])) {
-			unset($product_data['description']);
-		}
-		$session_desc = [
-			'payment_method_types' => $payment_types,
-			'mode' => 'payment',
-			'line_items' => [
-				[
-					'price_data' => [
-						'unit_amount' => $item['amount'],
-						'currency' => $item['currency'],
-						'product_data' => $product_data
-					],
-					'quantity' => 1,
-				]
-			],
-			// transfer the session id to the success URL
-			'success_url' => $url_success . '&session_id={CHECKOUT_SESSION_ID}',
-			'cancel_url' => $url_success, // on revient sur success aussi car response gerera l'echec du fait de l'absence de session_id
-			'locale' => stripe_locale($GLOBALS['spip_lang']),
-		];
-		if (!empty($item['images'])) {
-			$session_desc['line_items'][0]['price_data']['product_data']['images'] = $item['images'];
-		}
-
 		if (!$checkout_customer){
-			$session_desc['customer_email'] = $contexte['email'];
-		} else {
-			$session_desc['customer'] = $checkout_customer;
+			// TODO : creer un customer avec les billing infos
 		}
 
-		try {
-			$session = \Stripe\Checkout\Session::create($session_desc);
+		// mettre le customer id en base dans la transaction pour aider a la retrouver en cas d'echec
+		if ($checkout_customer and empty($row['pay_id'])) {
+			$row['pay_id'] = $customer->id;
+			sql_updateq("spip_transactions", ['pay_id' => $row['pay_id']], 'id_transaction='.intval($id_transaction));
 		}
-		catch (Exception $e) {
-			spip_log($s = "call_request: Erreur lors de la creation du Checkout\Session acte : ".$e->getMessage(), $mode . _LOG_ERREUR);
-			erreur_squelette("[$mode] $s");
-			return false;
+
+
+		$payment_types = array_intersect($cartes, array_keys($cartes_possibles));
+		if (!$payment_types) {
+			$payment_types = ['card'];
 		}
-		//ray($session_desc, $session);
 
-		$contexte['checkout_session_id'] = $session->id;
-	}
-
-	// est-ce un abonnement ?
-	if ($type === 'abo' and $echeance){
-		if ($echeance['montant'] > 0) {
-
-			/*
-			 * Create a Price from $item and $echeance
-			 * https://stripe.com/docs/api/prices/create
-			 */
-			$montant_echeance = bank_formatter_montant_selon_fraction($echeance['montant'], $devise_info['fraction'], 3);
-			$montant_initial = $montant_echeance;
-			// un montant_init=0 doit etre ignore (TODO distinguer null et 0 dans tous les modes de paiement recurrent)
-			if (isset($echeance['montant_init'])
-				and intval($m = bank_formatter_montant_selon_fraction($echeance['montant_init'], $devise_info['fraction'], 3))>0){
-				$montant_initial = $m;
-			}
-
-			$interval = 'month';
-			if (!empty($echeance['freq'])) {
-				switch ($echeance['freq']) {
-					case "day":
-					case "daily":
-						// debug purpose only, not fully supported by the bank plugin
-						$interval = 'day';
-						break;
-					case "week":
-					case "weekly":
-						// debug purpose only, not fully supported by the bank plugin
-						$interval = 'week';
-						break;
-					case "year":
-					case "yearly":
-						$interval = 'year';
-						break;
-					default:
-						$interval = 'month';
-				}
-			}
-
-			$session_desc = [
-				'payment_method_types' => $payment_types,
-				'mode' => 'subscription',
-				'line_items' => [],
-				// transfer the session id to the success URL
-				'success_url' => $url_success . '&session_id={CHECKOUT_SESSION_ID}',
-				'cancel_url' => $url_success, // on revient sur success aussi car response gerera l'echec du fait de l'absence de session_id
-				'locale' => stripe_locale($GLOBALS['spip_lang']),
-			];
-			if (!$checkout_customer){
-				$session_desc['customer_email'] = $contexte['email'];
-			} else {
-				$session_desc['customer'] = $checkout_customer;
-			}
-
-
+		// acte : utiliser une checkout session
+		if ($type==='acte'){
 			$product_data = [
 				'name' => $item['name'],
 				'description' => $item['description'],
@@ -316,77 +215,181 @@ function presta_stripe_call_request_dist($id_transaction, $transaction_hash, $co
 			if (empty($product_data['description'])) {
 				unset($product_data['description']);
 			}
-			$desc_item = [
-				'price_data' => [
-					'currency' => $contexte['currency'],
-					'unit_amount' => $montant_echeance,
-					'recurring' => [
-						'interval' => $interval,
-						'interval_count' => 1,
-						//'trial_period_days' => 0, // default
-					],
-					//'billing_scheme' => 'per_unit', // implicite, non modifiable via price_data
-					'product_data' => $product_data
+			$session_desc = [
+				'payment_method_types' => $payment_types,
+				'mode' => 'payment',
+				'line_items' => [
+					[
+						'price_data' => [
+							'unit_amount' => $item['amount'],
+							'currency' => $item['currency'],
+							'product_data' => $product_data
+						],
+						'quantity' => 1,
+					]
 				],
-				'quantity' => 1
+				// transfer the session id to the success URL
+				'success_url' => $url_success . '&session_id={CHECKOUT_SESSION_ID}',
+				'cancel_url' => $url_success, // on revient sur success aussi car response gerera l'echec du fait de l'absence de session_id
+				'locale' => stripe_locale($GLOBALS['spip_lang']),
 			];
-
-			// toutes les echeances sont identiques : on cree un unique price et vogue la galere
-			// https://stripe.com/docs/billing/migration/migrating-prices
-			if ($montant_echeance === $montant_initial) {
-
-				$session_desc['line_items'][] = $desc_item;
-				//ray("Echeance unique : ",$session_desc);
-			}
-			elseif (intval($montant_initial) < intval($montant_echeance)) {
-				$session_desc['line_items'][] = $desc_item;
-
-				$montant_remise = bank_formatter_montant_selon_fraction($echeance['montant'] - $echeance['montant_init'], $devise_info['fraction'], 3);
-
-				// et on ajoute une remise pour la premiere echeance
-				// et on ajoute un coupon pour la premiere echeance de l'abonnement
-				$coupon = \Stripe\Coupon::create([
-					'currency' => $contexte['currency'],
-					'amount_off' => $montant_remise,
-					'duration' => 'once'
-				]);
-				$session_desc['discounts'][0]['coupon'] = $coupon->id;
-				//ray("Première echeance reduite : ",$session_desc);
-			}
-			elseif (intval($montant_initial) > intval($montant_echeance)) {
-
-				$montant_surcharge = bank_formatter_montant_selon_fraction($echeance['montant_init'] - $echeance['montant'], $devise_info['fraction'], 3);
-
-				// et on ajoute une surcharge pour la premiere echeance
-				$product_data['name'] = "1ère échéance complément ". $item['name'];
-				$desc_item_first = [
-					'price_data' => [
-						'currency' => $contexte['currency'],
-						'unit_amount' => $montant_surcharge,
-						'product_data' => $product_data
-					],
-					'quantity' => 1
-				];
-
-				$session_desc['line_items'][] = $desc_item_first;
-				$session_desc['line_items'][] = $desc_item;
-				//ray("Première echeance plus elevee : ",$session_desc);
+			if (!empty($item['images'])) {
+				$session_desc['line_items'][0]['price_data']['product_data']['images'] = $item['images'];
 			}
 
+			if (!$checkout_customer){
+				$session_desc['customer_email'] = $contexte['email'];
+			} else {
+				$session_desc['customer'] = $checkout_customer;
+			}
 
 			try {
 				$session = \Stripe\Checkout\Session::create($session_desc);
 			}
 			catch (Exception $e) {
-				spip_log($s = "call_request: Erreur lors de la creation du Checkout\Session abonnement : ".$e->getMessage(), $mode . _LOG_ERREUR);
+				spip_log($s = "call_request: Erreur lors de la creation du Checkout\Session acte : ".$e->getMessage(), $mode . _LOG_ERREUR);
 				erreur_squelette("[$mode] $s");
 				return false;
 			}
+			//ray($session_desc, $session);
 
 			$contexte['checkout_session_id'] = $session->id;
-			//ray($session_desc, $session);
 		}
 
+		// est-ce un abonnement ?
+		if ($type === 'abo' and $echeance){
+			if ($echeance['montant'] > 0) {
+
+				/*
+				 * Create a Price from $item and $echeance
+				 * https://stripe.com/docs/api/prices/create
+				 */
+				$montant_echeance = bank_formatter_montant_selon_fraction($echeance['montant'], $devise_info['fraction'], 3);
+				$montant_initial = $montant_echeance;
+				// un montant_init=0 doit etre ignore (TODO distinguer null et 0 dans tous les modes de paiement recurrent)
+				if (isset($echeance['montant_init'])
+					and intval($m = bank_formatter_montant_selon_fraction($echeance['montant_init'], $devise_info['fraction'], 3))>0){
+					$montant_initial = $m;
+				}
+
+				$interval = 'month';
+				if (!empty($echeance['freq'])) {
+					switch ($echeance['freq']) {
+						case "day":
+						case "daily":
+							// debug purpose only, not fully supported by the bank plugin
+							$interval = 'day';
+							break;
+						case "week":
+						case "weekly":
+							// debug purpose only, not fully supported by the bank plugin
+							$interval = 'week';
+							break;
+						case "year":
+						case "yearly":
+							$interval = 'year';
+							break;
+						default:
+							$interval = 'month';
+					}
+				}
+
+				$session_desc = [
+					'payment_method_types' => $payment_types,
+					'mode' => 'subscription',
+					'line_items' => [],
+					// transfer the session id to the success URL
+					'success_url' => $url_success . '&session_id={CHECKOUT_SESSION_ID}',
+					'cancel_url' => $url_success, // on revient sur success aussi car response gerera l'echec du fait de l'absence de session_id
+					'locale' => stripe_locale($GLOBALS['spip_lang']),
+				];
+				if (!$checkout_customer){
+					$session_desc['customer_email'] = $contexte['email'];
+				} else {
+					$session_desc['customer'] = $checkout_customer;
+				}
+
+
+				$product_data = [
+					'name' => $item['name'],
+					'description' => $item['description'],
+					'metadata' => $item['metadata'],
+				];
+				if (empty($product_data['description'])) {
+					unset($product_data['description']);
+				}
+				$desc_item = [
+					'price_data' => [
+						'currency' => $contexte['currency'],
+						'unit_amount' => $montant_echeance,
+						'recurring' => [
+							'interval' => $interval,
+							'interval_count' => 1,
+							//'trial_period_days' => 0, // default
+						],
+						//'billing_scheme' => 'per_unit', // implicite, non modifiable via price_data
+						'product_data' => $product_data
+					],
+					'quantity' => 1
+				];
+
+				// toutes les echeances sont identiques : on cree un unique price et vogue la galere
+				// https://stripe.com/docs/billing/migration/migrating-prices
+				if ($montant_echeance === $montant_initial) {
+
+					$session_desc['line_items'][] = $desc_item;
+					//ray("Echeance unique : ",$session_desc);
+				}
+				elseif (intval($montant_initial) < intval($montant_echeance)) {
+					$session_desc['line_items'][] = $desc_item;
+
+					$montant_remise = bank_formatter_montant_selon_fraction($echeance['montant'] - $echeance['montant_init'], $devise_info['fraction'], 3);
+
+					// et on ajoute une remise pour la premiere echeance
+					// et on ajoute un coupon pour la premiere echeance de l'abonnement
+					$coupon = \Stripe\Coupon::create([
+						'currency' => $contexte['currency'],
+						'amount_off' => $montant_remise,
+						'duration' => 'once'
+					]);
+					$session_desc['discounts'][0]['coupon'] = $coupon->id;
+					//ray("Première echeance reduite : ",$session_desc);
+				}
+				elseif (intval($montant_initial) > intval($montant_echeance)) {
+
+					$montant_surcharge = bank_formatter_montant_selon_fraction($echeance['montant_init'] - $echeance['montant'], $devise_info['fraction'], 3);
+
+					// et on ajoute une surcharge pour la premiere echeance
+					$product_data['name'] = "1ère échéance complément ". $item['name'];
+					$desc_item_first = [
+						'price_data' => [
+							'currency' => $contexte['currency'],
+							'unit_amount' => $montant_surcharge,
+							'product_data' => $product_data
+						],
+						'quantity' => 1
+					];
+
+					$session_desc['line_items'][] = $desc_item_first;
+					$session_desc['line_items'][] = $desc_item;
+					//ray("Première echeance plus elevee : ",$session_desc);
+				}
+
+
+				try {
+					$session = \Stripe\Checkout\Session::create($session_desc);
+				}
+				catch (Exception $e) {
+					spip_log($s = "call_request: Erreur lors de la creation du Checkout\Session abonnement : ".$e->getMessage(), $mode . _LOG_ERREUR);
+					erreur_squelette("[$mode] $s");
+					return false;
+				}
+
+				$contexte['checkout_session_id'] = $session->id;
+				//ray($session_desc, $session);
+			}
+
+		}
 	}
 
 

--- a/presta/stripe/config.php
+++ b/presta/stripe/config.php
@@ -27,3 +27,64 @@ function stripe_lister_cartes_config($c, $cartes = true){
 	return $liste;
 }
 
+/**
+ * Action pour déclencher le checkout session chez Stripe quand l'utilisateur a cliqué sur le bouton "payer par Stripe"
+ * (et non avant)
+ *
+ * @return void
+ */
+function action_stripe_process_checkout_dist() {
+	$securiser_action = charger_fonction('securiser_action', 'inc');
+	$arg = $securiser_action();
+
+	$action = base64_decode($arg, true);
+	$action = str_replace("&amp;", "&", $action);
+	if ($action
+	  and $id_transaction = parametre_url($action, 'id_transaction')
+	  and $transaction_hash = parametre_url($action, 'transaction_hash')
+	  and $sign = parametre_url($action, 'sign')) {
+
+		$contexte = [
+			'id_transaction' => $id_transaction,
+			'transaction_hash' => $transaction_hash,
+			'sign' => $sign,
+		];
+		if (!is_null($abo = parametre_url($action, 'abo'))) {
+			$contexte['abo'] = $abo;
+		}
+
+		if (strpos($action, '/bank.api/') !== false) {
+			$arg_api = explode('/bank.api/', $action, 2);
+			$arg_api = end($arg_api);
+			$arg_api = explode('/', $arg_api);
+			$presta = reset($arg_api);
+		}
+		else {
+			$presta = parametre_url($action, 'bankp');
+		}
+		include_spip('inc/bank');
+		$config = bank_config($presta);
+		$mode = '';
+		if ($config) {
+			$mode = $config['presta'];
+			if (isset($config['mode_test']) AND $config['mode_test']){
+				$mode .= "_test";
+			}
+		}
+		if ($mode and bank_response_simple($mode, $contexte)) {
+			$quoi = (($contexte['abo'] ?? false) ? 'abo' : 'acte');
+			$call_request = charger_fonction('request', 'presta/stripe/call');
+			$contexte = $call_request($id_transaction, $transaction_hash, $config, $quoi, ['process_checkout' => true]);
+			$checkout_session_id = $contexte['checkout_session_id'];
+			$redirect = _request('redirect');
+			// et on finit le hit ajax avec le checkout_session_id en plus
+			$redirect = parametre_url($redirect, 'checkout_session_id', $checkout_session_id, '&');
+			$redirect = parametre_url($redirect, 'autosubmit', 1, '&');
+			$GLOBALS['redirect'] = $redirect;
+		}
+		else {
+			$mode = $mode ?: 'stripe';
+			spip_log("action_stripe_process_checkout_dist: action corrompue '$action' impossible de traiter la demande", $mode . _LOG_ERREUR);
+		}
+	}
+}

--- a/presta/stripe/payer/abonnement.html
+++ b/presta/stripe/payer/abonnement.html
@@ -14,12 +14,20 @@
   <div class="payer_mode payer_stripe payer_abonnement">
 	  <h4 class="titre h4">[(#ENV{payer_par_title,<:bank:abonnement_par_carte_bancaire:>})]</h4>
 	  [<p class="explication">(#ENV{config/presta}|bank_explication_mode_paiement)</p>]
-	  <div class='boutons'>
-		  [(#SET{id,[abo(#ID_TRANSACTION)]})][(#SET{texte,<:bank:payer_par_carte_bancaire:>})]
-		  [(#BOUTON_ACTION{[(#ENV*{logos})],#ENV*{action},stripe_button_#GET{id},'','',[stripe_button_(#GET{id})_callback\(\)]})]
-		  [<script src="https://js.stripe.com/v3/"></script>
-		  <script type="text/javascript">(#INCLURE{fond=presta/stripe/payer/inc-checkout-js,env,id=#GET{id}}|compacte{js})</script>]
+	  <div class='boutons[ (#ENV{autosubmit}|?{loading})]'>
+		  [(#SET{texte,<:bank:payer_par_carte_bancaire:>})]
+		  [(#ENV{checkout_session_id}|oui)
+		    [(#SET{id,[abo(#ID_TRANSACTION)]})]
+		    [(#BOUTON_ACTION{[(#ENV*{logos})],#ENV*{action},stripe_button_#GET{id},'','',[stripe_button_(#GET{id})_callback\(\)]})]
+		    [<script src="https://js.stripe.com/v3/"></script>
+		    <script type="text/javascript">(#INCLURE{fond=presta/stripe/payer/inc-checkout-js,env,id=#GET{id}}|compacte{js})</script>]
+		  ]
+		  [(#ENV{checkout_session_id}|non)
+			[(#BOUTON_ACTION{[(#ENV*{logos})],[(#URL_ACTION_AUTEUR{stripe_process_checkout,[(#ENV*{action}|base64_encode)],#SELF})],ajax stripe_button_process})]
+		    <script type="text/javascript">jQuery(function(){jQuery('.payer_stripe .boutons').on('click', '.stripe_button_process', function(){jQuery(this).closest('.boutons').addClass('loading')})})</script>
+		  ]
 	  </div>
 	  [(#ENV{sandbox}|oui)<div class="info"><:bank:info_mode_test{presta=Stripe}:></div>]
+	  <style type="text/css">.payer_stripe .loading .bouton_action_post{position: relative} .payer_stripe .loading .bouton_action_post::after{content:'';display: block;position: absolute;left:0;right: 0;top:0;bottom: 0;background: rgba(255,255,255,0.5) url([(#CHEMIN{images/loader.svg})]) no-repeat center;background-size: contain;}</style>
   </div>
 </BOUCLE_trans>

--- a/presta/stripe/payer/abonnement.php
+++ b/presta/stripe/payer/abonnement.php
@@ -23,8 +23,9 @@ if (!defined('_ECRIRE_INC_VERSION')){
  */
 function presta_stripe_payer_abonnement_dist($config, $id_transaction, $transaction_hash, $options = array()){
 
+	$process_checkout = $options['process_checkout'] ?? false;
 	$call_request = charger_fonction('request', 'presta/stripe/call');
-	$contexte = $call_request($id_transaction, $transaction_hash, $config, 'abo');
+	$contexte = $call_request($id_transaction, $transaction_hash, $config, 'abo', ['process_checkout' => $process_checkout]);
 
 	// si moyen de paiement pas applicable
 	if (!$contexte){
@@ -59,6 +60,5 @@ function presta_stripe_payer_abonnement_dist($config, $id_transaction, $transact
 
 	$contexte = array_merge($options, $contexte);
 
-	return recuperer_fond('presta/stripe/payer/abonnement', $contexte);
+	return recuperer_fond('presta/stripe/payer/abonnement', $contexte, $process_checkout ? [] : ['ajax' => true]);
 }
-

--- a/presta/stripe/payer/acte.html
+++ b/presta/stripe/payer/acte.html
@@ -14,12 +14,20 @@
   <div class="payer_mode payer_stripe payer_acte">
 	  <h4 class="titre h4">[(#ENV{payer_par_title,<:bank:payer_par_carte_bancaire:>})]</h4>
 	  [<p class="explication">(#ENV{config/presta}|bank_explication_mode_paiement)</p>]
-	  <div class='boutons'>
-		  [(#SET{id,[acte(#ID_TRANSACTION)]})][(#SET{texte,<:bank:payer_par_carte_bancaire:>})]
-		  [(#BOUTON_ACTION{[(#ENV*{logos})],#ENV*{action},stripe_button_#GET{id},'','',[stripe_button_(#GET{id})_callback\(\)]})]
-		  [<script src="https://js.stripe.com/v3/"></script>
-		  <script type="text/javascript">(#INCLURE{fond=presta/stripe/payer/inc-checkout-js,env,id=#GET{id}}|compacte{js})</script>]
+	  <div class='boutons[ (#ENV{autosubmit}|?{loading})]'>
+		  [(#SET{texte,<:bank:payer_par_carte_bancaire:>})]
+		  [(#ENV{checkout_session_id}|oui)
+		    [(#SET{id,[acte(#ID_TRANSACTION)]})]
+		    [(#BOUTON_ACTION{[(#ENV*{logos})],#ENV*{action},stripe_button_#GET{id},'','',[stripe_button_(#GET{id})_callback\(\)]})]
+		    [<script src="https://js.stripe.com/v3/"></script>
+		    <script type="text/javascript">(#INCLURE{fond=presta/stripe/payer/inc-checkout-js,env,id=#GET{id}}|compacte{js})</script>]
+		  ]
+		  [(#ENV{checkout_session_id}|non)
+		    [(#BOUTON_ACTION{[(#ENV*{logos})],[(#URL_ACTION_AUTEUR{stripe_process_checkout,[(#ENV*{action}|base64_encode)],#SELF})],ajax stripe_button_process})]
+		    <script type="text/javascript">jQuery(function(){jQuery('.payer_stripe .boutons').on('click', '.stripe_button_process', function(){jQuery(this).closest('.boutons').addClass('loading')})})</script>
+		  ]
 	  </div>
 	  [(#ENV{sandbox}|oui)<div class="info"><:bank:info_mode_test{presta=Stripe}:></div>]
+	  <style type="text/css">.payer_stripe .loading .bouton_action_post{position: relative} .payer_stripe .loading .bouton_action_post::after{content:'';display: block;position: absolute;left:0;right: 0;top:0;bottom: 0;background: rgba(255,255,255,0.5) url([(#CHEMIN{images/loader.svg})]) no-repeat center;background-size: contain;}</style>
   </div>
 </BOUCLE_trans>

--- a/presta/stripe/payer/acte.php
+++ b/presta/stripe/payer/acte.php
@@ -23,8 +23,9 @@ if (!defined('_ECRIRE_INC_VERSION')){
  */
 function presta_stripe_payer_acte_dist($config, $id_transaction, $transaction_hash, $options = array()){
 
+	$process_checkout = $options['process_checkout'] ?? false;
 	$call_request = charger_fonction('request', 'presta/stripe/call');
-	$contexte = $call_request($id_transaction, $transaction_hash, $config);
+	$contexte = $call_request($id_transaction, $transaction_hash, $config, 'acte', ['process_checkout' => $process_checkout]);
 
 	// si moyen de paiement pas applicable
 	if (!$contexte){
@@ -59,6 +60,5 @@ function presta_stripe_payer_acte_dist($config, $id_transaction, $transaction_ha
 
 	$contexte = array_merge($options, $contexte);
 
-	return recuperer_fond('presta/stripe/payer/acte', $contexte);
+	return recuperer_fond('presta/stripe/payer/acte', $contexte, $process_checkout ? [] : ['ajax' => true]);
 }
-

--- a/presta/stripe/payer/inc-checkout-js.html
+++ b/presta/stripe/payer/inc-checkout-js.html
@@ -27,4 +27,12 @@ function stripe_button_#ENV{id}_callback() {
 
 	//e.preventDefault();
 	return false;
+}[(#ENV{autosubmit}|oui)
+function run_callback_#ENV{id}() {
+	if (typeof Stripe !== 'undefined') {
+		return stripe_button_#ENV{id}_callback();
+	}
+	setTimeout(run_callback_#ENV{id}, 100);
 }
+run_callback_#ENV{id}();
+]


### PR DESCRIPTION
ne pas ouvrir de checkout_session chez Stripe (ce qui prépare une transaction) à chaque affichage de la page de paiement, mais uniquement après que l'utilisateur a cliqué sur le bouton de paiement par Stripe. On passe par une action intermédiaire qui initialise la session puis on ajoute le checkout_session_id dans l'environnement.

Si quelqu'un a surchargé le squelette acte.html ou abonnement.html il aura un soucis de compatibilité car il n'aura pas de checkout_session_id et pas le mécanisme pour en générer un, mais ça se règle assez facilement en mettant à jour le html ou en reforçant la création du checkout_session_id dans le acte.php

Refs: #86