### PR TITLE
Ajout de Sherlocks 2 (LCL) 

### DIFF
--- a/presta/sipsv2/inc-configurer.html
+++ b/presta/sipsv2/inc-configurer.html
@@ -10,6 +10,8 @@
 			<option value="#GET{val}"[(#ENV{#ENV{casier,''}/service,#GET{defaut}}|=={#GET{val}}|oui)selected="selected"]>[(#GET{val}|ucfirst)] (La Banque Postale)</option>
 			#SET{val,sogenactif}
 			<option value="#GET{val}"[(#ENV{#ENV{casier,''}/service,#GET{defaut}}|=={#GET{val}}|oui)selected="selected"]>[(#GET{val}|ucfirst)] (Soci&eacute;t&eacute; G&eacute;n&eacute;rale)</option>
+			#SET{val,sherlocks2}
+			<option value="#GET{val}"[(#ENV{#ENV{casier,''}/service,#GET{defaut}}|=={#GET{val}}|oui)selected="selected"]>[(#GET{val}|ucfirst)] (LCL)</option>
 		</select>
 	</li>
 	#SET{name,#ENV{casier,''}_merchant_id}#SET{obli,''}#SET{defaut,''}#SET{erreurs,#ENV**{erreurs}|table_valeur{#GET{name}}}

--- a/presta/sipsv2/inc/sipsv2.php
+++ b/presta/sipsv2/inc/sipsv2.php
@@ -47,9 +47,9 @@ function sipsv2_url_serveur($config){
 			}
 		case "sherlocks2":
 			if ($config['mode_test']){
-				$host = "https://sherlocks-payment-webinit-simu.secure.lcl.fr/";
+				$host = "https://sherlocks-payment-webinit-simu.secure.lcl.fr";
 			} else {
-				$host = "https://sherlocks-payment-webinit.secure.lcl.fr/";
+				$host = "https://sherlocks-payment-webinit.secure.lcl.fr";
 			}
 			break;
 		default:

--- a/presta/sipsv2/inc/sipsv2.php
+++ b/presta/sipsv2/inc/sipsv2.php
@@ -45,6 +45,12 @@ function sipsv2_url_serveur($config){
 			} else {
 				$host = "https://payment-webinit.scellius.labanquepostale.fr";
 			}
+		case "sherlocks2":
+			if ($config['mode_test']){
+				$host = "https://sherlocks-payment-webinit-simu.secure.lcl.fr/";
+			} else {
+				$host = "https://sherlocks-payment-webinit.secure.lcl.fr/";
+			}
 			break;
 		default:
 			$host = "https://payment-webinit.simu.sogenactif.com";


### PR DESCRIPTION
Permet d'utiliser Sherlocks 2 de LCL.

Attention, il faut bien demander à LCL la version complète (et pas la version simplifiée mise à jour depuis Sherlocks 1).
Attention bis, bank générant la référence de transaction, il faut demander dans le contrat LCL à désactiver l'option de génération automatique de la part du serveur LCL.