### PR TITLE
feat: le mode de paiement 'simulation' prend en charge complètement les abonnements

### DIFF
--- a/inc/bank.php
+++ b/inc/bank.php
@@ -820,6 +820,12 @@ function bank_simple_call_response($config, $response = null){
 	// est-ce un abonnement ?
 	if (isset($response['abo_uid']) AND $response['abo_uid']){
 		$set['abo_uid'] = $response['abo_uid'];
+		if (isset($response['pay_id']) AND $response['pay_id']){
+			$set['pay_id'] = $response['pay_id'];
+		}
+		if (isset($response['auteur_id']) AND $response['auteur_id']){
+			$set['auteur_id'] = $response['auteur_id'];
+		}
 	}
 
 	sql_updateq("spip_transactions", $set, "id_transaction=" . intval($id_transaction));
@@ -857,41 +863,6 @@ function bank_simple_call_response($config, $response = null){
 		);
 
 		$res = 'wait';
-	}
-
-	// Si c'est un abonnnement, activer ou resilier
-	if ($id_transaction
-		AND $row = sql_fetsel("*", "spip_transactions", "id_transaction=" . intval($id_transaction))
-		AND $abo_uid = $row['abo_uid']){
-
-		// c'est un paiement reussi ou en 'wait'
-		if ($res){
-			// date de fin de mois de validite de la carte
-			$date_fin = "0000-00-00 00:00:00";
-			if ($row['validite']){
-				list($year, $month) = explode('-', $row['validite']);
-				$date_fin = bank_date_fin_mois($year, $month);
-			}
-
-			if ($activer_abonnement = charger_fonction('activer_abonnement', 'abos', true)){
-				$activer_abonnement($id_transaction, $abo_uid, $mode, $date_fin);
-			}
-		}
-
-		// c'est un echec, il faut le resilier, que ce soit la premiere ou la Nieme transaction
-		if (!$res){
-
-			if ($resilier = charger_fonction('resilier', 'abos', true)){
-				$options = array(
-					'notify_bank' => false, // pas la peine : abo deja resilie vu paiement refuse
-					'immediat' => true,
-					'message' => "[bank] Transaction #$id_transaction refusee",
-					'erreur' => true,
-				);
-				$resilier("uid:" . $abo_uid, $options);
-			}
-		}
-
 	}
 
 	return array($id_transaction, $res);

--- a/presta/simu/call/response.php
+++ b/presta/simu/call/response.php
@@ -37,17 +37,134 @@ function presta_simu_call_response_dist($config, $response = null){
 	if (_request('status')=='fail'){
 		$response['fail'] = "Simulation echec paiement";
 	}
-
-	// generer un numero d'abonne simule si besoin (sauf si on en a deja un)
-	if (_request('abo')){
-		if ($response['id_transaction']
-			AND $abo_uid = sql_getfetsel("abo_uid", "spip_transactions", "id_transaction=" . intval($response['id_transaction']))){
-			$response['abo_uid'] = $abo_uid;
-		} else {
-			$response['abo_uid'] = substr(md5($response['id_transaction'] . "-" . time()), 0, 10);
+	else {
+		if (empty($response['autorisation_id'])) {
+			// generer un numero d'autorisation fake
+			$response['autorisation_id'] = 'simu_' . substr(md5(uniqid()), 0, 16);
 		}
 	}
 
-	return bank_simple_call_response($config, $response);
+	// a la creation $response['abo'] contient le abo_uid généré avant paiement, pour activation de l'abonnement post-paiement
+	// au renouvellement $response['abo'] vaut 'recurrence' et le abo_uid est dans $response['abo_uid']
+	$recurrence = false;
+	if (!empty($response['abo']) and empty($response['fail'])) {
+		include_spip('inc/bank_recurrences');
+		if ($response['abo'] === 'creation') {
+			$id_transaction = $response['id_transaction'];
+			$transaction_hash = $response['transaction_hash'];
+			// si on ne sait pas décrire les échéances, on fail
+			// et dans ce cas indiquer qu'on est dans une création d'abonnement pour le traitement au retour d'autorisation
+			if (!$abo_uid = bank_recurrence_creer($id_transaction, $mode)) {
+				$response['fail'] = "Simulation echec création récurrence";
+			}
+			else {
+				$response['abo_uid'] = $abo_uid;
+				// simuler un pay_id et auteur_id de la plateforme de paiement
+				// qu'on devra retrouver à la recurrence
+				$response['pay_id'] = 'pay_' . substr(md5(uniqid()), 0, 16);
+				$response['auteur_id'] = 'cust_' . substr(md5(uniqid()), 0, 16);
+			}
+		}
+		elseif ($response['abo'] === 'recurrence'
+		  and !empty($response['abo_uid'])) {
+			$id_transaction = $response['id_transaction'];
+			$transaction_hash = $response['transaction_hash'];
 
+			// verifier qu'on a bien les infos pour générer un nouveau paiement
+			if (empty($response['payment_data'])
+			  or !$payment_data = json_decode($response['payment_data'], true)
+			  or empty($payment_data['pay_id'])
+			  or empty($payment_data['auteur_id'])) {
+				return bank_transaction_echec($id_transaction, array(
+					'mode' => $mode,
+					'erreur' => "Paramètre payment_data incorrect ou invalide pour générer un paiement récurrent (simu)",
+					'log' => json_encode($response),
+					'send_mail' => true,
+				));
+			}
+
+			// si on a levé le define, il faut simuler un echec des paiements d'echeance d'abonnement
+			// (tous si true ou celui la seulement si correspond a abo_uid)
+			if (defined('_BANK_SIMU_FAIL_ECHEANCES_ABONNEMENTS')
+				and in_array(_BANK_SIMU_FAIL_ECHEANCES_ABONNEMENTS, [true, $response['abo_uid']], true)) {
+				$response['fail'] = "Simulation echec paiement echeance abonnement";
+			}
+			else {
+				// rien à faire, c'est une simulation...
+				// mais on simule la reutilisation du pay_id (identification qui permet de déclencher le paiement)
+				// et auteur_id (identifiant client chez le prestataire de paiement)
+				$response['pay_id'] = $payment_data['pay_id'];
+				$response['auteur_id'] = $payment_data['auteur_id'];
+			}
+
+
+			$recurrence = true;
+	    }
+		elseif (!in_array($response['abo'], ['creation', 'recurrence']) or empty($response['abo_uid'])) {
+			spip_log("call_response : valeur abo/abo_uid incoherent " . var_export($response, true), $mode . _LOG_ERREUR);
+			// echec ? ne pas declencher le paiement...
+			return bank_transaction_invalide($response['id_transaction'], array(
+				'mode' => $mode,
+				'erreur' => "Paramètre abo/abo_uid incorrect",
+				'log' => json_encode($response),
+				'update' => true,
+			));
+		}
+	}
+
+	list($id_transaction, $success) = bank_simple_call_response($config, $response);
+
+	if (
+		isset($response['abo'])
+		&& $response['abo'] === 'creation'
+		&& !empty($response['abo_uid'])
+		&& $id_transaction
+		&& $success === true
+	) {
+		// on passe le pay_id pour stockage dans la recurrence, il sera fourni au renouvellement pour déclencher un nouveau paiement
+		$payment_data = json_encode(array('pay_id' => $response['pay_id'], 'auteur_id' => $response['auteur_id']));
+		$res = bank_recurrence_activer($id_transaction, $response['abo_uid'], $mode, $payment_data);
+		if (!$res) {
+			bank_recurrence_invalide($id_transaction,array(
+				'mode' => $mode,
+				'erreur' => "echec activation abonnement " . $response['abo_uid'],
+				'log' => json_encode($response),
+				'sujet' => "Echec activation recurrence T #$id_transaction / ".$response['abo_uid'],
+				'where' => 'bank_recurrence_activer',
+			));
+		}
+	}
+
+	if ($recurrence and !empty($response['abo_uid'])) {
+		if ($id_transaction and $success === true) {
+			// on passe le pay_id pour stockage dans la recurrence, il sera fourni au renouvellement pour déclencher un nouveau paiement
+			$payment_data = json_encode(array('pay_id' => $response['pay_id'], 'auteur_id' => $response['auteur_id']));
+			$res = bank_recurrence_prolonger($id_transaction, $response['abo_uid'], $mode, $payment_data);
+			if (!$res) {
+				bank_recurrence_invalide($id_transaction,array(
+					'mode' => $mode,
+					'erreur' => "echec renouvellement abonnement " . $response['abo_uid'],
+					'log' => json_encode($response),
+					'sujet' => "Echec renouvellement recurrence T #$id_transaction / ".$response['abo_uid'],
+					'where' => 'bank_recurrence_renouveler',
+				));
+			}
+		}
+
+		// c'est un echec, il faut le resilier, que ce soit la premiere ou la Nieme transaction
+		if (!$success){
+			$res = bank_recurrence_resilier($id_transaction, $response['abo_uid'], $mode);
+			if (!$res) {
+				bank_recurrence_invalide($id_transaction,array(
+					'mode' => $mode,
+					'erreur' => "echec resiliation recurrence " . $response['abo_uid'],
+					'log' => json_encode($response),
+					'sujet' => "Echec resiliation recurrence suite à T #$id_transaction / ".$response['abo_uid'],
+					'where' => 'bank_recurrence_resilier',
+				));
+			}
+		}
+	}
+
+	return array($id_transaction, $success);
 }

--- a/presta/simu/payer/abonnement.html
+++ b/presta/simu/payer/abonnement.html
@@ -16,7 +16,7 @@
 	[<p class="explication">(#ENV{config/presta}|bank_explication_mode_paiement{abo})</p>]
 	<div class='boutons'>
 		#BOUTON_ACTION{'Simuler l&#39;abonnement',#ENV{action}}
-		#BOUTON_ACTION{'Simuler l&#39;abonnement avec paiement en attente',#ENV{action_wait}}
+		<!--#BOUTON_ACTION{'Simuler l&#39;abonnement avec paiement en attente',#ENV{action_wait}}-->
 		#BOUTON_ACTION{'Simuler un echec de l&#39;abonnement',#ENV{action}|parametre_url{status,fail}}
 	</div>
 </div>

--- a/presta/simu/payer/abonnement.php
+++ b/presta/simu/payer/abonnement.php
@@ -26,7 +26,7 @@ function presta_simu_payer_abonnement_dist($config, $id_transaction, $transactio
 	$contexte = array(
 		'id_transaction' => $id_transaction,
 		'transaction_hash' => $transaction_hash,
-		'abo' => 'oui',
+		'abo' => 'creation',
 	);
 	$contexte['sign'] = bank_sign_response_simple($config['presta'], $contexte);
 


### PR DESCRIPTION
en mettant en place un paiement reccurent géré en interne par le plugin.

Il y aura donc automatiquement un paiement simulé déclenché à chaque echeance, considéré comme réussi par défaut. Il est possible de faire echouer les paiements simulés des échéances avec la constante `_BANK_SIMU_FAIL_ECHEANCES_ABONNEMENTS` soit en la définissant à `true` pour faire echouer toutes les récurrences, soit en lui donnant la valeur d'un abo_uid pour faire echouer spécifiquement le paiement d'une récurrence.
On peut ainsi tester aussi les scenarii de fin d'abonnement en cas d'echec de paiement