### PR TITLE
Permettre de s'abonner plus d'une heure, un jour ou un mois avec Stri…

### DIFF
--- a/presta/stripe/call/request.php
+++ b/presta/stripe/call/request.php
@@ -291,6 +291,8 @@ function presta_stripe_call_request_dist($id_transaction, $transaction_hash, $co
 					}
 				}
 
+				$interval_count = 1;
+
 				$session_desc = [
 					'payment_method_types' => $payment_types,
 					'mode' => 'subscription',
@@ -321,7 +323,7 @@ function presta_stripe_call_request_dist($id_transaction, $transaction_hash, $co
 						'unit_amount' => $montant_echeance,
 						'recurring' => [
 							'interval' => $interval,
-							'interval_count' => 1,
+							'interval_count' => $echeance['interval_count'],
 							//'trial_period_days' => 0, // default
 						],
 						//'billing_scheme' => 'per_unit', // implicite, non modifiable via price_data


### PR DESCRIPTION
Pour permettre de s'abonner plus d'une heure, un jour ou un mois avec Stripe, il faut prendre en compte la variable "interval_count" trop autoritairement passé à "1" sur le plugin actuel.