### PR TITLE
fix: Augmenter le nombre de resultats retournés par l’api stripe dans le report

### DIFF
--- a/spip-cli/BankStripeReport.php
+++ b/spip-cli/BankStripeReport.php
@@ -99,6 +99,7 @@ class BankStripeReport extends Command {
 				'gte' => strtotime($from),
 				'lte' => strtotime($to),
 			],
+			'limit' => 100,
 		]);
 
 		$this->io->care(sprintf('%s payouts', count($payouts)));


### PR DESCRIPTION

C’était 10 par défaut, on met 100, le maximum.