### PR TITLE
Fix : éviter un Warning en cas d'appel direct d'une URL de webhook Stripe

### DIFF
--- a/presta/stripe/call/autoresponse.php
+++ b/presta/stripe/call/autoresponse.php
@@ -110,7 +110,7 @@ function stripe_retrieve_event($config, $auto = 'auto'){
 	if (isset($config[$key_webhook_secret]) and $config[$key_webhook_secret]){
 		$endpoint_secret = $config[$key_webhook_secret];
 		$payload = @file_get_contents('php://input');
-		$sig_header = $_SERVER['HTTP_STRIPE_SIGNATURE'];
+		$sig_header = $_SERVER['HTTP_STRIPE_SIGNATURE'] ?? '';
 
 		try {
 			\Stripe\WebhookSignature::verifyHeader($payload, $sig_header, $endpoint_secret, 300);


### PR DESCRIPTION
A priori ça n'est pas un cas d'usage "normal" mais autant éviter de faire un Warning en cas de serveur mal configuré