### PR TITLE
Gestion des noms et autres infos avec entites_html (payzen)

### DIFF
--- a/inc/bank.php
+++ b/inc/bank.php
@@ -534,6 +534,10 @@ function bank_porteur_infos_facturation($transaction){
 	$lignes = array_filter($lignes);
 	$infos['adresse'] = implode("\n", $lignes);
 
+	// importer les entites dans le charset si possible,
+	// c'est préférable pour les envois vers les presta bancaires
+	include_spip('inc/filtres');
+	$infos = array_map('filtrer_entites', $infos);
 	#spip_log("bank_porteur_infos_facturation:".$transaction['id_transaction'].":".json_encode($infos),'dspdbg');
 
 	return $infos;

--- a/presta/payzen/inc/payzen.php
+++ b/presta/payzen/inc/payzen.php
@@ -240,10 +240,13 @@ function payzen_available_cards($config){
  * @return string
  */
 function payzen_form_hidden($config, $parms){
+	include_spip('inc/filtres_mini');
 	$parms['signature'] = payzen_signe_contexte($parms, payzen_key($config), payzen_sign_algorithm($config));
 	$hidden = "";
 	foreach ($parms as $k => $v){
-		$hidden .= "<input type='hidden' name='$k' value='" . str_replace("'", "&#39;", $v) . "' />";
+		// il faut passer en entité les &,",<,> pour qu'ils soient reçus à l'identique
+		$v_s = spip_htmlspecialchars($v);
+		$hidden .= "<input type=\"hidden\" name=\"$k\" value=\"$v_s\" />";
 	}
 
 	return $hidden;


### PR DESCRIPTION
cf #134 le bug se produisait 
* si on avait en amont un plugin comme le plugin Commandes qui renseigne les infos facturation (via le plugin coordonnées ?) qui fait passer le nom via typo ou autre filtre qui transforme certains caractères (comme le `’`) en entité html (`&#8217;`)
* parce qu'on échappait pas correctement les valeurs dans les input hidden envoyés à payzen : le `&#8217;` ou autre entité étant injecté à l'identique dans le champ `value="..."` l'entité était interprétée en son équivalence au moment du POST vers Payzen, qui calculait la signature sur un `’` et non sur `&#8217;`

On répare donc les 2 problèmes 
* en sanitizant proprement les hidden du form pour Payzen
* en filtrant les entités en amont dans la fonction `bank_porteur_infos_facturation()` utilisée par tous les modes de paiement

On ne s'aventure pas à toucher aux autres presta, car par exemple sur paybox il est explicitement documenté qu'il ne faut pas échapper en entités html les valeur https://github.com/nursit/bank/blob/master/presta/paybox/inc/paybox.php#L222

